### PR TITLE
Migrated developer toolbar to Laminas

### DIFF
--- a/view/laminas-developer-tools/toolbar/lmc-rbac.phtml
+++ b/view/laminas-developer-tools/toolbar/lmc-rbac.phtml
@@ -3,99 +3,99 @@
 $collection = $this->collector->getCollection();
 ?>
 
-<div class="zdt-toolbar-entry">
-    <div class="zdt-toolbar-preview">
-        <!-- Image Provided by https://github.com/Nitecon with New BSD License to ZfcRbac -->
-        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="ZfcRbac">
-        <span class="zdt-toolbar-info">Settings</span>
+<div class="laminas-toolbar-entry">
+    <div class="laminas-toolbar-preview">
+        <!-- Image Provided by https://github.com/Nitecon with New BSD License to LmcRbac -->
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="LmcRbac">
+        <span class="laminas-toolbar-info">Settings</span>
     </div>
 
-    <div class="zdt-toolbar-detail">
-        <span class="zdt-toolbar-info-heading">Settings Details</span>
+    <div class="laminas-toolbar-detail">
+        <span class="laminas-toolbar-info-heading">Settings Details</span>
 
-        <span class="zdt-toolbar-info">
-            <span class="zdt-detail-label">Guest role</span>
-            <span class="zdt-detail-value">&nbsp;</span>
-            <span class="zdt-detail-value-right"><?= $collection['options']['guest_role']; ?></span>
+        <span class="laminas-toolbar-info">
+            <span class="laminas-detail-label">Guest role</span>
+            <span class="laminas-detail-value">&nbsp;</span>
+            <span class="laminas-detail-value-right"><?= $collection['options']['guest_role']; ?></span>
         </span>
-        <span class="zdt-toolbar-info">
-            <span class="zdt-detail-label">Guard protection policy</span>
-            <span class="zdt-detail-value">&nbsp;</span>
-            <span class="zdt-detail-value-right"><?= $collection['options']['protection_policy']; ?></span>
+        <span class="laminas-toolbar-info">
+            <span class="laminas-detail-label">Guard protection policy</span>
+            <span class="laminas-detail-value">&nbsp;</span>
+            <span class="laminas-detail-value-right"><?= $collection['options']['protection_policy']; ?></span>
         </span>
     </div>
 </div>
 
-<div class="zdt-toolbar-entry">
-    <div class="zdt-toolbar-preview">
-        <!-- Image Provided by https://github.com/Nitecon with New BSD License to ZfcRbac -->
-        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="ZfcRbac">
-        <span class="zdt-toolbar-info">Guards</span>
+<div class="laminas-toolbar-entry">
+    <div class="laminas-toolbar-preview">
+        <!-- Image Provided by https://github.com/Nitecon with New BSD License to LmcRbac -->
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="LmcRbac">
+        <span class="laminas-toolbar-info">Guards</span>
     </div>
-    <div class="zdt-toolbar-detail">
-        <span class="zdt-toolbar-info-heading">Guards details</span>
+    <div class="laminas-toolbar-detail">
+        <span class="laminas-toolbar-info-heading">Guards details</span>
 
         <?php if (count($collection['guards']) > 0): ?>
             <?php foreach ($collection['guards'] as $type => $rules): ?>
-                <span class="zdt-toolbar-info">
-                    <span class="zdt-detail-label">Type</span>
-                    <span class="zdt-detail-value">&nbsp;</span>
-                    <span class="zdt-detail-value-right"><?= $type; ?></span>
+                <span class="laminas-toolbar-info">
+                    <span class="laminas-detail-label">Type</span>
+                    <span class="laminas-detail-value">&nbsp;</span>
+                    <span class="laminas-detail-value-right"><?= $type; ?></span>
                 </span>
 
-                <span class="zdt-toolbar-info">
-                    <span class="zdt-detail-label">Rules</span>
-                    <span class="zdt-detail-value">&nbsp;</span>
-                    <span class="zdt-detail-value-right">
+                <span class="laminas-toolbar-info">
+                    <span class="laminas-detail-label">Rules</span>
+                    <span class="laminas-detail-value">&nbsp;</span>
+                    <span class="laminas-detail-value-right">
                         <?php
-                        $d = new \Zend\Debug\Debug();
-                        $d->dump($rules);
+                        // This requires that symfony/var-dumper is installed
+                        dump($rules);
                         ?>
                     </span>
                     </span>
             <?php endforeach; ?>
         <?php else: ?>
-            <span class="zdt-toolbar-info">
-                <span class="zdt-detail-value">No guards</span>
+            <span class="laminas-toolbar-info">
+                <span class="laminas-detail-value">No guards</span>
             </span>
         <?php endif; ?>
     </div>
 </div>
 
-<div class="zdt-toolbar-entry">
-    <div class="zdt-toolbar-preview">
-        <!-- Image Provided by https://github.com/Nitecon with New BSD License to ZfcRbac -->
-        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="ZfcRbac">
-        <span class="zdt-toolbar-info">Roles</span>
+<div class="laminas-toolbar-entry">
+    <div class="laminas-toolbar-preview">
+        <!-- Image Provided by https://github.com/Nitecon with New BSD License to LmcRbac -->
+        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAABGdBTUEAALGPC/xhBQAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAAewQAAHsEBw2lUUwAAAAl2cEFnAAAAFAAAABQAozsq0QAAAylJREFUOMudVM1rXFUU/51775s3X+9NZpKmE0MC2lBGS6QahRIMuOnC6l7Upbsqhf4FhS66qRstIoV2UwhaLdUu6qISKBRhIqb5KJMJSSbTyUeTaGo68+Z9zPu410UjLaZpmBw4m8v93fM7v9+5h/CSGD1bgAYIszf5yVhxK7h4Y/mGkeCh5UZ7YviLDkeGcqg9uoKZhcmetwazZ5knz1VX7FP9h+LJvi59obzqWF2GBseXu7B0+9K7J5cWrMRirTmlmZrXczihFQpmX29vasRMiY+bS9bx7TWH+75E04uiuhPOgtFYoPB7xDCXSAk72x3vbthh4er12iMq3Xr/prdqn4oirHXk4y7pIqYRDiknzLTqPoVu+F9tEAFSKkgAiiiIJfk2cfJSmVjm4aZnnvlq9nvBGTr6crou3eg1ckLAiSAjCSggzgkwtL3k0gjoVgBYI0DMCtAKZI8QSUGGVFBKAUQ7dxnaCUaAmeDgjJSQwDNllWrroWdOPCXCGTxhb7ibPiew6HmG7YVSCg0nhB+qNdF44s+1crpigSLQwRgKRlhcd2Xtb29JVKr2VLol7ZSg9MH6BRgj3K/attOS02J8ZnsyK6iaS4vBA8kHwPElJpasKoAH4vKd9ZU3+pJ3okgf1LX2NWREKK3YKK86vwFYFV9+8AruV6zrJNVn/V2xfLu+BBK4N1tf/6se/MCIwBkDbk9sb/Z3xbo703zYjHMQFBiwbwoiFBcs/PLHP9+6vhxVgBLFeQsn38xE45XmN0aCDx/JJ4fNBIfcZyYFI0zXbPxYfHz3cTO8RIBU2Nk2TU/hvYLZKK+5c5yzkbcHjM6enA4zqSGT2p1ZQ8NGPcTXv66X/qw0TwtO83KnPgcAuxVh+qGNa2cKKxduLj/YssKhfFY/nEkJhAqIFBDtfCkJ4F65gfM/LU/dLdVPZ5Ji3H1uje2y4MRRE5PV5rETR43zHw51fjR0xIg9dZ9guSHGZp74P49v3apsuOcYoSz/p8wLPSUACsjkO2KfvjNgfHH81fTrni9RnG+UJirWd64vRwE09sLuN7cD2bT4PIwULDe6AmDxZYB/AbS8alQXJDY6AAAAJXRFWHRkYXRlOmNyZWF0ZQAyMDEzLTEwLTA1VDAwOjAzOjEyLTA0OjAwtQbKIQAAACV0RVh0ZGF0ZTptb2RpZnkAMjAxMy0xMC0wNVQwMDowMzoxMi0wNDowMMRbcp0AAAAASUVORK5CYII=" alt="LmcRbac">
+        <span class="laminas-toolbar-info">Roles</span>
     </div>
-    <div class="zdt-toolbar-detail">
-        <span class="zdt-toolbar-info zdt-toolbar-info-heading">Loaded identity roles</span>
+    <div class="laminas-toolbar-detail">
+        <span class="laminas-toolbar-info laminas-toolbar-info-heading">Loaded identity roles</span>
 
         <?php if (count($collection['roles']) > 0): ?>
             <?php foreach ($collection['roles'] as $key => $value): ?>
-                <span class="zdt-toolbar-info">
+                <span class="laminas-toolbar-info">
                     <?php if (is_string($key)): ?>
-                        <span class="zdt-detail-label" style="text-transform: none"><?= $key; ?></span>
-                        <span class="zdt-detail-value">&nbsp;</span>
-                        <span class="zdt-detail-value-right"><?= implode(', ', $value); ?></span>
+                        <span class="laminas-detail-label" style="text-transform: none"><?= $key; ?></span>
+                        <span class="laminas-detail-value">&nbsp;</span>
+                        <span class="laminas-detail-value-right"><?= implode(', ', $value); ?></span>
                     <?php else: ?>
-                        <span class="zdt-detail-value"><?= $value; ?></span>
+                        <span class="laminas-detail-value"><?= $value; ?></span>
                     <?php endif; ?>
                 </span>
             <?php endforeach; ?>
         <?php else: ?>
-            <span class="zdt-toolbar-info">
-                <span class="zdt-detail-value">No identity roles</span>
+            <span class="laminas-toolbar-info">
+                <span class="laminas-detail-value">No identity roles</span>
             </span>
         <?php endif; ?>
 
-        <span class="zdt-toolbar-info zdt-toolbar-info-heading">Permissions for loaded identity roles</span>
+        <span class="laminas-toolbar-info laminas-toolbar-info-heading">Permissions for loaded identity roles</span>
 
         <?php foreach ($collection['permissions'] as $roleName => $permissions): ?>
-            <span class="zdt-toolbar-info">
-                <span class="zdt-detail-label" style="text-transform: none"><?= $roleName; ?></span>
-                <span class="zdt-detail-value">&nbsp;</span>
-                <span class="zdt-detail-value-right"><?= implode(', ', $permissions); ?></span>
+            <span class="laminas-toolbar-info">
+                <span class="laminas-detail-label" style="text-transform: none"><?= $roleName; ?></span>
+                <span class="laminas-detail-value">&nbsp;</span>
+                <span class="laminas-detail-value-right"><?= implode(', ', $permissions); ?></span>
             </span>
         <?php endforeach; ?>
     </div>


### PR DESCRIPTION
Migrated the developer toolbars to Laminas.
Removed the use of the deprecated Zend\Debug and replaced with Symfony/var-dumper::dump()