### PR TITLE
Laminas commons migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # CHANGELOG
 
-For changelog, please refer to the [releases](https://github.com/ZF-Commons/ZfcRbac/releases) page.
+For changelog, please refer to the [releases](https://github.com/Laminas-Commons/LmcRbac/releases) page.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ZfcRbac is an access control library based on the RBAC permission model.
 ## Optional
 
 - [DoctrineModule](https://github.com/doctrine/DoctrineModule): if you want to use some built-in role and permission providers.
-- [ZendDeveloperTools](https://github.com/zendframework/ZendDeveloperTools): if you want to have useful stats added to
+- [Laminas\DeveloperTools](https://github.com/zendframework/Laminas\DeveloperTools): if you want to have useful stats added to
 the Zend Developer toolbar.
 
 ## Upgrade

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ $ php composer.phar require laminas-commons/lmc-rbac:^1.0
 ```
 
 Enable the module by adding `LmcRbac` key to your `application.config.php` file. Customize the module by copy-pasting
-the `zfc_rbac.global.php.dist` file to your `config/autoload` folder.
+the `lmc_rbac.global.php.dist` file to your `config/autoload` folder.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
-# ZfcRbac
+# LmcRbac
 
-[![Develop Branch Build Status](https://travis-ci.org/ZF-Commons/zfc-rbac.svg?branch=develop)](http://travis-ci.org/ZF-Commons/zfc-rbac)
-[![Coverage Status](https://coveralls.io/repos/github/ZF-Commons/zfc-rbac/badge.svg?branch=develop)](https://coveralls.io/github/ZF-Commons/zfc-rbac?branch=develop)
-[![Latest Stable Version](https://poser.pugx.org/zf-commons/zfc-rbac/v/stable)](https://packagist.org/packages/zf-commons/zfc-rbac)
-[![Total Downloads](https://poser.pugx.org/zf-commons/zfc-rbac/downloads)](https://packagist.org/packages/zf-commons/zfc-rbac)
-[![Latest Unstable Version](https://poser.pugx.org/zf-commons/zfc-rbac/v/unstable)](https://packagist.org/packages/zf-commons/zfc-rbac)
-[![License](https://poser.pugx.org/zf-commons/zfc-rbac/license)](https://packagist.org/packages/zf-commons/zfc-rbac)
-[![Join the chat at https://gitter.im/ZFCommons/zfc-rbac](https://badges.gitter.im/ZFCommons/zfc-rbac.svg)](https://gitter.im/ZFCommons/zfc-rbac?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Version](https://poser.pugx.org/laminas-commons/lmc-rbac/version)](//packagist.org/packages/laminas-commons/lmc-rbac)
+[![Total Downloads](https://poser.pugx.org/laminas-commons/lmc-rbac/downloads)](//packagist.org/packages/laminas-commons/lmc-rbac)
+[![License](https://poser.pugx.org/laminas-commons/lmc-rbac/license)](//packagist.org/packages/laminas-commons/lmc-rbac)
+[![Master Branch Build Status](https://travis-ci.org/Laminas-Commons/LmcRbac.svg?branch=master)](http://travis-ci.org/Laminas-Commons/LmcRbac)
+[![Gitter](https://badges.gitter.im/LaminasCommons/community.svg)](https://gitter.im/LaminasCommons/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Coverage Status](https://coveralls.io/repos/github/Laminas-Commons/LmcRbac/badge.svg?branch=master)](https://coveralls.io/github/Laminas-Commons/LmcRbac?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Laminas-Commons/LmcRbac/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Laminas-Commons/LmcRbac/?branch=master)
 
-ZfcRbac is an access control library based on the RBAC permission model.
+Role-based access control module to provide additional features on top of Zend\Permissions\Rbac
 
-**Work In Progress**; *you are looking at the next version, for stable visit the master branch.*
+Based on [ZF-Commons/zfc-rbac](https://github.com/ZF-Commons/zfc-rbac) v3.x. If you are looking for the Laminas version
+of zfc-rbac v2, please use [Laminas-Commons/LmcRbacMvc](https://github.com/Laminas-Commons/LmcRbacMvc).
+
+**Work In Progress**
 
 ## Requirements
 
-- PHP 7.1 or higher
-
-> If you are looking for older version of ZfcRbac, please refer to the 2.x branch.
-> If you are using ZfcRbac 2.0, please upgrade to 3.0.
+- PHP 7.2 or higher
 
 ## Optional
 
@@ -27,20 +27,20 @@ the Zend Developer toolbar.
 
 ## Upgrade
 
-You can find an [upgrade guide](UPGRADE.md) to quickly upgrade your application from major versions of ZfcRbac.
+You can find an [upgrade guide](UPGRADE.md) to quickly upgrade your application from major versions of LmcRbac.
 
 ## Installation
 
-ZfcRbac only officially supports installation through Composer. For Composer documentation, please refer to
+LmcRbac only officially supports installation through Composer. For Composer documentation, please refer to
 [getcomposer.org](http://getcomposer.org/).
 
 Install the module:
 
 ```sh
-$ php composer.phar require zf-commons/zfc-rbac:^3.0
+$ php composer.phar require laminas-commons/lmc-rbac:^1.0
 ```
 
-Enable the module by adding `ZfcRbac` key to your `application.config.php` file. Customize the module by copy-pasting
+Enable the module by adding `LmcRbac` key to your `application.config.php` file. Customize the module by copy-pasting
 the `zfc_rbac.global.php.dist` file to your `config/autoload` folder.
 
 ## Documentation
@@ -48,9 +48,9 @@ the `zfc_rbac.global.php.dist` file to your `config/autoload` folder.
 The official documentation is available in the [/docs](docs/) folder.
 
 You can also find some Doctrine entities in the [/data](data/) folder that will help you to more quickly take advantage
-of ZfcRbac.
+of LmcRbac.
 
 ## Support
 
-- File issues at https://github.com/ZF-Commons/zfc-rbac/issues.
-- Ask questions in the [zf-common gitter](https://gitter.im/ZFCommons/zfc-rbac) chat.
+- File issues at https://github.com/Laminas-Commons/LmcRbac/issues.
+- Ask questions in the [LaminasCommons gitter](https://gitter.im/LaminasCommons/community) chat.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,7 @@
 ## From v2.x to v3
 
 - ZfcRbac is no longer a ZF2 module. Instead, it fully embraces middlewares and can be used for any middleware
-library like Zend\Expressive. As a consequence, its scope has been dramatically reduced and now only provide
+library like Mezzio. As a consequence, its scope has been dramatically reduced and now only provide
 the base logic for authorization.
 
 ## From v2.2 to v2.3

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,18 @@
 # Upgrade guide
 
+## From ZfcRbac v3 to LmcRbac v1
+
+The ZF-Commons orgnisation has been moved to Laminas-Commons and ZfcRbac has been split into two repositories.
+
+- [LmcRbacMvc](https://github.com/Laminas-Commons/LmcRbacMvc) contains the old version 2 of ZfcRbac.
+- LmcRbac contains the version 3 of ZfcRbac, which was only released as v3.alpha.1.
+
+To upgrade 
+
+- uninstall `zf-commons/zfc-rbac:3.0.0-alpha.1`.
+- install `laminas-commons/lmc-rbac:^1.0` 
+- replace config keys `zfc_rbac` with `lmc_rbac`.
+
 ## From v2.x to v3
 
 - ZfcRbac is no longer a ZF2 module. Instead, it fully embraces middlewares and can be used for any middleware

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -9,9 +9,10 @@ The ZF-Commons orgnisation has been moved to Laminas-Commons and ZfcRbac has bee
 
 To upgrade 
 
-- uninstall `zf-commons/zfc-rbac:3.0.0-alpha.1`.
-- install `laminas-commons/lmc-rbac:^1.0` 
-- replace config keys `zfc_rbac` with `lmc_rbac`.
+- Uninstall `zf-commons/zfc-rbac:3.0.0-alpha.1`.
+- Install `laminas-commons/lmc-rbac:^1.0` 
+- Change `zfc-rbac.global.php` to `lmc-rbac.global.php` and update the key `zfc_rbac` to `lmc_rbac`.
+- Review your code for usages of the `ZfcRbac/*` namespace to `LmcRbac/*` namespace.
 
 ## From v2.x to v3
 

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
       "dev-master": "2.4-dev",
       "dev-develop": "3.0-dev"
     },
-    "zf": {
+    "laminas": {
       "component": "ZfcRbac",
       "config-provider": "ZfcRbac\\ConfigProvider"
     }

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
   "name": "zf-commons/zfc-rbac",
-  "description": "Zend Framework 2 Module that provides a layer of features of Zend\\Permissions\\Rbac",
+  "description": "Laminas Module that provides a layer of features of Laminas\\Permissions\\Rbac",
   "type": "library",
   "license": "MIT",
   "keywords": [
     "module",
-    "zf2",
+    "laminas",
     "rbac",
     "permissions"
   ],

--- a/composer.json
+++ b/composer.json
@@ -36,8 +36,8 @@
   ],
   "require": {
     "php": "^7.2",
-    "zendframework/zend-servicemanager": "^3.3",
-    "zendframework/zend-stdlib": "^3.1"
+    "laminas/laminas-servicemanager": "^3.3",
+    "laminas/laminas-stdlib": "^3.1"
   },
   "require-dev": {
     "malukenho/docheader": "^0.1.7",

--- a/composer.json
+++ b/composer.json
@@ -49,12 +49,12 @@
   },
   "autoload": {
     "psr-4": {
-      "ZfcRbac\\": "src/"
+      "LmcRbac\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "ZfcRbacTest\\": "test/"
+      "LmcRbacTest\\": "test/"
     }
   },
   "extra": {
@@ -63,8 +63,8 @@
       "dev-develop": "3.0-dev"
     },
     "laminas": {
-      "component": "ZfcRbac",
-      "config-provider": "ZfcRbac\\ConfigProvider"
+      "component": "LmcRbac",
+      "config-provider": "LmcRbac\\ConfigProvider"
     }
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "zf-commons/zfc-rbac",
+  "name": "laminas-commons/lmc-rbac",
   "description": "Laminas Module that provides a layer of features of Laminas\\Permissions\\Rbac",
   "type": "library",
   "license": "MIT",
@@ -59,8 +59,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "2.4-dev",
-      "dev-develop": "3.0-dev"
+      "dev-master": "1.1-dev"
     },
     "laminas": {
       "component": "LmcRbac",

--- a/config/config.global.php
+++ b/config/config.global.php
@@ -38,7 +38,7 @@ return [
          * It must be an array that contains configuration for the role provider. The provider config
          * must follow the following format:
          *
-         *      'ZfcRbac\Role\InMemoryRoleProvider' => [
+         *      'LmcRbac\Role\InMemoryRoleProvider' => [
          *          'role1' => [
          *              'children'    => ['children1', 'children2'], // OPTIONAL
          *              'permissions' => ['edit', 'read'] // OPTIONAL

--- a/config/config.global.php
+++ b/config/config.global.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
  */
 
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
 
         /**
          * Set the guest role

--- a/data/FlatRole.php.dist
+++ b/data/FlatRole.php.dist
@@ -19,7 +19,7 @@
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Rbac\Role\RoleInterface;
-use ZfcRbac\Permission\PermissionInterface;
+use LmcRbac\Permission\PermissionInterface;
 
 /**
  * @ORM\Entity

--- a/data/HierarchicalRole.php.dist
+++ b/data/HierarchicalRole.php.dist
@@ -19,7 +19,7 @@
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Rbac\Role\HierarchicalRoleInterface;
-use ZfcRbac\Permission\PermissionInterface;
+use LmcRbac\Permission\PermissionInterface;
 
 /**
  * @ORM\Entity

--- a/data/Permission.php.dist
+++ b/data/Permission.php.dist
@@ -17,7 +17,7 @@
  */
 
 use Doctrine\ORM\Mapping as ORM;
-use ZfcRbac\Permission\PermissionInterface;
+use LmcRbac\Permission\PermissionInterface;
 
 /**
  * @ORM\Entity

--- a/data/README.md
+++ b/data/README.md
@@ -1,4 +1,4 @@
-These files are only provided as-in, and are not part of ZfcRbac. They provide you some basic Doctrine ORM
+These files are only provided as-in, and are not part of LmcRbac. They provide you some basic Doctrine ORM
 entities that you can use as a starting point.
 
 ## Flat role or hierarchical role?

--- a/docs/01. Introduction.md
+++ b/docs/01. Introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Welcome to the official documentation of ZfcRbac!
+Welcome to the official documentation of LmcRbac!
 
 In this part, the following questions will be answered:
 

--- a/docs/01. Introduction.md
+++ b/docs/01. Introduction.md
@@ -6,7 +6,7 @@ In this part, the following questions will be answered:
 
 * Why should I use an authorization module?
 * What is the Rbac model?
-* How can I integrate ZfcRbac into my application?
+* How can I integrate LmcRbac into my application?
 
 ## Why should I use an authorization module?
 
@@ -28,7 +28,7 @@ The basic idea of Rbac is to use roles and permissions:
 * **Roles** request access to **Permissions**
 * **Permissions** are granted to **Roles**
 
-By default, ZfcRbac can be used for two kinds of Rbac model:
+By default, LmcRbac can be used for two kinds of Rbac model:
 
 * Flat RBAC model: in this model, roles cannot have children. This is ideal for smaller application, as it is easier
 to understand, and the database design is simpler (no need for a join table).
@@ -36,9 +36,9 @@ to understand, and the database design is simpler (no need for a join table).
 permission, this model also checks recursively if any of its child roles also have the permission.
 
 
-## How can I integrate ZfcRbac into my application?
+## How can I integrate LmcRbac into my application?
 
-ZfcRbac offers multiple ways to protect your application:
+LmcRbac offers multiple ways to protect your application:
 
 * Using **Guards**: those classes act as "firewalls" that block access to routes and/or controllers. Guards are usually
   configured using PHP arrays, and are executed early in the MVC dispatch process. Typically this happens right after

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -11,21 +11,21 @@ the README file.
 
 ## Specifying an identity provider
 
-By default, ZfcRbac internally uses the `Zend\Authentication\AuthenticationService` service key to retrieve the user (logged or
+By default, ZfcRbac internally uses the `Laminas\Authentication\AuthenticationService` service key to retrieve the user (logged or
 not). Therefore, you must implement and register this service in your application by adding those lines in your `module.config.php` file:
 
 ```php
 return [
     'service_manager' => [
         'factories' => [
-	        'Zend\Authentication\AuthenticationService' => function($sm) {
+	        'Laminas\Authentication\AuthenticationService' => function($sm) {
 	            // Create your authentication service!
 	        }
 	    ]
     ]
 ];
 ```
-The identity given by `Zend\Authentication\AuthenticationService` must implement `ZfcRbac\Identity\IdentityInterface`. Note that the default identity provided with ZF2 does not implement this interface, neither does the ZfcUser suite.
+The identity given by `Laminas\Authentication\AuthenticationService` must implement `ZfcRbac\Identity\IdentityInterface`. Note that the default identity provided with ZF2 does not implement this interface, neither does the ZfcUser suite.
 
 ZfcRbac is flexible enough to use something else than the built-in `AuthenticationService`, by specifying custom
 identity providers. For more information, refer [to this section](/docs/03. Role providers.md#identity-providers).

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -37,7 +37,7 @@ grants access to any route that begins with `admin` (or is exactly `admin`) to t
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
 	        'ZfcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin']
@@ -60,7 +60,7 @@ inherits the *member* permissions.
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
 	        \ZfcRbac\Role\InMemoryRoleProvider::class => [
 	            'admin' => [

--- a/docs/02. Quick Start.md
+++ b/docs/02. Quick Start.md
@@ -11,7 +11,7 @@ the README file.
 
 ## Specifying an identity provider
 
-By default, ZfcRbac internally uses the `Laminas\Authentication\AuthenticationService` service key to retrieve the user (logged or
+By default, LmcRbac internally uses the `Laminas\Authentication\AuthenticationService` service key to retrieve the user (logged or
 not). Therefore, you must implement and register this service in your application by adding those lines in your `module.config.php` file:
 
 ```php
@@ -25,9 +25,9 @@ return [
     ]
 ];
 ```
-The identity given by `Laminas\Authentication\AuthenticationService` must implement `ZfcRbac\Identity\IdentityInterface`. Note that the default identity provided with ZF2 does not implement this interface, neither does the ZfcUser suite.
+The identity given by `Laminas\Authentication\AuthenticationService` must implement `LmcRbac\Identity\IdentityInterface`. Note that the default identity provided with ZF2 does not implement this interface, neither does the ZfcUser suite.
 
-ZfcRbac is flexible enough to use something else than the built-in `AuthenticationService`, by specifying custom
+LmcRbac is flexible enough to use something else than the built-in `AuthenticationService`, by specifying custom
 identity providers. For more information, refer [to this section](/docs/03. Role providers.md#identity-providers).
 
 ## Adding a guard
@@ -39,7 +39,7 @@ grants access to any route that begins with `admin` (or is exactly `admin`) to t
 return [
     'lmc_rbac' => [
         'guards' => [
-	        'ZfcRbac\Guard\RouteGuard' => [
+	        'LmcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin']
 	        ]
         ]
@@ -47,12 +47,12 @@ return [
 ];
 ```
 
-ZfcRbac have several built-in guards, and you can also register your own guards. For more information, refer
+LmcRbac have several built-in guards, and you can also register your own guards. For more information, refer
 [to this section](/docs/04. Guards.md#built-in-guards).
 
 ## Adding a role provider
 
-RBAC model is based on roles. Therefore, for ZfcRbac to work properly, it must be aware of all the roles that are
+RBAC model is based on roles. Therefore, for LmcRbac to work properly, it must be aware of all the roles that are
 used inside your application.
 
 This configuration creates an *admin* role that has a children role called *member*. The *admin* role automatically
@@ -62,7 +62,7 @@ inherits the *member* permissions.
 return [
     'lmc_rbac' => [
         'role_provider' => [
-	        \ZfcRbac\Role\InMemoryRoleProvider::class => [
+	        \LmcRbac\Role\InMemoryRoleProvider::class => [
 	            'admin' => [
 	                'children'    => ['member'],
 	                'permissions' => ['delete']
@@ -79,15 +79,15 @@ return [
 In this example, the *admin* role have two permissions: `delete` and `edit` (because it inherits the permissions from
 its child), while the *member* role only has the permission `edit`.
 
-ZfcRbac have several built-in role providers, and you can also register your own role providers. For more information,
+LmcRbac have several built-in role providers, and you can also register your own role providers. For more information,
 refer [to this section](/docs/03. Role providers.md#built-in-role-providers).
 
 ## Registering a strategy
 
-When a guard blocks access to a route/controller, or if you throw the `ZfcRbac\Exception\UnauthorizedException`
-exception in your service, ZfcRbac automatically performs some logic for you depending on the view strategy used.
+When a guard blocks access to a route/controller, or if you throw the `LmcRbac\Exception\UnauthorizedException`
+exception in your service, LmcRbac automatically performs some logic for you depending on the view strategy used.
 
-For instance, if you want ZfcRbac to automatically redirect all unauthorized requests to the "login" route, add
+For instance, if you want LmcRbac to automatically redirect all unauthorized requests to the "login" route, add
 the following code in the `onBootstrap` method of your `Module.php` class:
 
 ```php
@@ -96,7 +96,7 @@ public function onBootstrap(EventInterface $e)
     $t = $e->getTarget();
 
     $t->getEventManager()->attach(
-        $t->getServiceManager()->get('ZfcRbac\View\Strategy\RedirectStrategy')
+        $t->getServiceManager()->get('LmcRbac\View\Strategy\RedirectStrategy')
     );
 }
 ```
@@ -104,20 +104,20 @@ public function onBootstrap(EventInterface $e)
 By default, `RedirectStrategy` redirects all unauthorized requests to a route named "login" when user is not connected 
 and to a route named "home" when user is connected. This is, of course, entirely configurable.
 
-> For flexibility purpose, ZfcRbac **does not** register any strategy for you by default!
+> For flexibility purpose, LmcRbac **does not** register any strategy for you by default!
 
 For more information about built-in strategies, refer [to this section](/docs/05. Strategies.md#built-in-strategies).
 
 ## Using the authorization service
 
-Now that ZfcRbac is properly configured, you can inject the authorization service in any class and use it to check
+Now that LmcRbac is properly configured, you can inject the authorization service in any class and use it to check
 if the current identity is granted to do something.
 
-The authorization service is registered inside the service manager using the following key: `ZfcRbac\Service\AuthorizationService`.
+The authorization service is registered inside the service manager using the following key: `LmcRbac\Service\AuthorizationService`.
 Once injected, you can use it as follow:
 
 ```php
-use ZfcRbac\Exception\UnauthorizedException;
+use LmcRbac\Exception\UnauthorizedException;
 
 public function delete()
 {

--- a/docs/03. Role providers.md
+++ b/docs/03. Role providers.md
@@ -21,7 +21,7 @@ the workflow harder and can lead to security problems that are very hard to spot
 
 Identity providers return the current identity. Most of the time, this means the logged user. ZfcRbac comes with a
 default identity provider (`ZfcRbac\Identity\AuthenticationIdentityProvider`) that uses the
-`Zend\Authentication\AuthenticationService` service.
+`Laminas\Authentication\AuthenticationService` service.
 
 ### Create your own identity provider
 

--- a/docs/03. Role providers.md
+++ b/docs/03. Role providers.md
@@ -10,23 +10,23 @@ In this section, you will learn:
 ## What are role providers?
 
 A role provider is an object that returns a list of roles. Each role provider must implement the
-`ZfcRbac\Role\RoleProviderInterface` interface. The only required method is `getRoles`, and must return an array
+`LmcRbac\Role\RoleProviderInterface` interface. The only required method is `getRoles`, and must return an array
 of `Rbac\Role\RoleInterface` objects.
 
-Roles can come from any sources: in memory, from a file, from a database... However, please note that since ZfcRbac
+Roles can come from any sources: in memory, from a file, from a database... However, please note that since LmcRbac
 2.0, you can specify only one role provider per application. The reason is that having multiple role providers make
 the workflow harder and can lead to security problems that are very hard to spot.
 
 ## Identity providers?
 
-Identity providers return the current identity. Most of the time, this means the logged user. ZfcRbac comes with a
-default identity provider (`ZfcRbac\Identity\AuthenticationIdentityProvider`) that uses the
+Identity providers return the current identity. Most of the time, this means the logged user. LmcRbac comes with a
+default identity provider (`LmcRbac\Identity\AuthenticationIdentityProvider`) that uses the
 `Laminas\Authentication\AuthenticationService` service.
 
 ### Create your own identity provider
 
 If you want to implement your own identity provider, create a new class that implements
-`ZfcRbac\Identity\IdentityProviderInterface` class. Then, change the `identity_provider` option in ZfcRbac config,
+`LmcRbac\Identity\IdentityProviderInterface` class. Then, change the `identity_provider` option in LmcRbac config,
 as shown below:
 
 ```php
@@ -41,7 +41,7 @@ The identity provider is automatically pulled from the service manager.
 
 ## Built-in role providers
 
-ZfcRbac comes with two built-in role providers: `InMemoryRoleProvider` and `ObjectRepositoryRoleProvider`. A role
+LmcRbac comes with two built-in role providers: `InMemoryRoleProvider` and `ObjectRepositoryRoleProvider`. A role
 provider must be added to the `role_provider` subkey:
 
 ```php
@@ -65,7 +65,7 @@ Here is an example of the format you need to use:
 return [
     'lmc_rbac' => [
         'role_provider' => [
-            \ZfcRbac\Role\InMemoryRoleProvider::class => [
+            \LmcRbac\Role\InMemoryRoleProvider::class => [
                 'admin' => [
                     'children'    => ['member'],
                     'permissions' => ['article.delete']
@@ -93,7 +93,7 @@ If you are more confident with flat RBAC, the previous config can be re-written 
 return [
     'lmc_rbac' => [
         'role_provider' => [
-            \ZfcRbac\Role\InMemoryRoleProvider::class => [
+            \LmcRbac\Role\InMemoryRoleProvider::class => [
                 'admin' => [
                     'permissions' => [
                         'article.delete',
@@ -129,7 +129,7 @@ using the `object_repository` key:
 return [
     'lmc_rbac' => [
         'role_provider' => [
-            \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => [
+            \LmcRbac\Role\ObjectRepositoryRoleProvider::class => [
                 'object_repository'  => 'App\Repository\RoleRepository',
                 'role_name_property' => 'name'
             ]
@@ -144,7 +144,7 @@ Or you can specify the `object_manager` and `class_name` options:
 return [
     'lmc_rbac' => [
         'role_provider' => [
-            \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => [
+            \LmcRbac\Role\ObjectRepositoryRoleProvider::class => [
                 'object_manager'     => 'doctrine.entitymanager.orm_default',
                 'class_name'         => 'App\Entity\Role',
                 'role_name_property' => 'name'
@@ -162,7 +162,7 @@ Please note that your entity fetched from the table MUST implement the `Rbac\Rol
 
 ## Creating custom role providers
 
-To create a custom role providers, you first need to create a class that implements the `ZfcRbac\Role\RoleProviderInterface`
+To create a custom role providers, you first need to create a class that implements the `LmcRbac\Role\RoleProviderInterface`
 interface.
 
 Then, you need to add it to the role provider manager:

--- a/docs/03. Role providers.md
+++ b/docs/03. Role providers.md
@@ -31,7 +31,7 @@ as shown below:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'identity_provider' => 'MyCustomIdentityProvider'
     ]
 ];
@@ -46,7 +46,7 @@ provider must be added to the `role_provider` subkey:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             // Role provider config here!
         ]
@@ -63,7 +63,7 @@ Here is an example of the format you need to use:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             \ZfcRbac\Role\InMemoryRoleProvider::class => [
                 'admin' => [
@@ -91,7 +91,7 @@ If you are more confident with flat RBAC, the previous config can be re-written 
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             \ZfcRbac\Role\InMemoryRoleProvider::class => [
                 'admin' => [
@@ -127,7 +127,7 @@ using the `object_repository` key:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => [
                 'object_repository'  => 'App\Repository\RoleRepository',
@@ -142,7 +142,7 @@ Or you can specify the `object_manager` and `class_name` options:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => [
                 'object_manager'     => 'doctrine.entitymanager.orm_default',
@@ -169,7 +169,7 @@ Then, you need to add it to the role provider manager:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider_manager' => [
             'factories' => [
                 'Application\Role\CustomRoleProvider' => 'Application\Factory\CustomRoleProviderFactory'
@@ -183,7 +183,7 @@ You can now use it like any other role provider:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'role_provider' => [
             'Application\Role\CustomRoleProvider' => [
                 // Options

--- a/docs/04. Guards.md
+++ b/docs/04. Guards.md
@@ -8,7 +8,7 @@ In this section, you will learn:
 
 ## What are guards and when to use them?
 
-Guards (called firewalls in older versions of ZfcRbac) are listeners that are registered on a specific event of
+Guards (called firewalls in older versions of LmcRbac) are listeners that are registered on a specific event of
 the MVC workflow. They allow to quickly unauthorized requests.
 
 Here is a simple workflow without guards:
@@ -44,10 +44,10 @@ For instance, let's say you have two routes: "index" and "login". If you specify
 route to "member" role, your "login" route will become defacto unauthorized to anyone, unless you add a new rule for
 allowing the route "login" to "member" role.
 
-You can change it in ZfcRbac config, as follows:
+You can change it in LmcRbac config, as follows:
 
 ```php
-use ZfcRbac\Guard\GuardInterface;
+use LmcRbac\Guard\GuardInterface;
 
 return [
     'lmc_rbac' => [
@@ -61,7 +61,7 @@ deny policy is much more secure, but it needs much more configuration to work wi
 
 ## Built-in guards
 
-ZfcRbac comes with four guards, in order of priority :
+LmcRbac comes with four guards, in order of priority :
 
 * RouteGuard : protect a set of routes based on the identity roles
 * RoutePermissionsGuard : protect a set of routes based on roles permissions
@@ -101,7 +101,7 @@ where the key is a route pattern, and value an array of role names:
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin'],
                 'login'   => ['guest']
             ]
@@ -123,7 +123,7 @@ You can also use the wildcard character * for roles:
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'home' => ['*']
             ]
         ]
@@ -139,7 +139,7 @@ Finally, you can also omit the roles array to completly block a route, for maint
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'route_under_construction'
             ]
         ]
@@ -155,7 +155,7 @@ Note : this last example could be (and should be) written in a more explicit way
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'route_under_construction' => []
             ]
         ]
@@ -175,7 +175,7 @@ where the key is a route pattern, and value an array of permissions names:
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RoutePermissionsGuard' => [
+            'LmcRbac\Guard\RoutePermissionsGuard' => [
                 'admin*' => ['admin'],
                 'post/manage' => ['post.update', 'post.delete']
             ]
@@ -190,12 +190,12 @@ In the previous example, one must have ```post.update``` **AND** ```post.delete`
 to access the ```post/manage``` route. You can also specify an OR condition like so:
 
 ```php
-use ZfcRbac\Guard\GuardInterface;
+use LmcRbac\Guard\GuardInterface;
 
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RoutePermissionsGuard' => [
+            'LmcRbac\Guard\RoutePermissionsGuard' => [
                 'post/manage'   => [
                     'permissions' => ['post.update', 'post.delete'],
                     'condition'   => GuardInterface::CONDITION_OR
@@ -219,7 +219,7 @@ You can also use the wildcard character * for permissions:
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RoutePermissionsGuard' => [
+            'LmcRbac\Guard\RoutePermissionsGuard' => [
                 'home' => ['*']
             ]
         ]
@@ -235,7 +235,7 @@ Finally, you can also use an empty array to completly block a route, for mainten
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RoutePermissionsGuard' => [
+            'LmcRbac\Guard\RoutePermissionsGuard' => [
                 'route_under_construction' => []
             ]
         ]
@@ -256,7 +256,7 @@ The ControllerGuard allows to protect a controller. You must provide an array of
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\ControllerGuard' => [
+            'LmcRbac\Guard\ControllerGuard' => [
                 [
                     'controller' => 'MyController',
                     'roles'      => ['guest', 'member']
@@ -280,7 +280,7 @@ You can also specify optional actions, so that the rule only apply to one or sev
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\ControllerGuard' => [
+            'LmcRbac\Guard\ControllerGuard' => [
                 [
                     'controller' => 'MyController',
                     'actions'    => ['read', 'edit'],
@@ -298,7 +298,7 @@ You can combine a generic rule and a specific action rule for the same controlle
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\ControllerGuard' => [
+            'LmcRbac\Guard\ControllerGuard' => [
                 [
                     'controller' => 'PostController',
                     'roles'      => ['member']
@@ -327,7 +327,7 @@ The ControllerPermissionsGuard allows to protect a controller using permissions.
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\ControllerPermissionsGuard' => [
+            'LmcRbac\Guard\ControllerPermissionsGuard' => [
                 [
                     'controller'  => 'MyController',
                     'permissions' => ['post.update', 'post.delete']
@@ -358,7 +358,7 @@ should always protect your services too.
 
 ## Creating custom guards
 
-ZfcRbac is flexible enough to allow you to create custom guard. Let's say we want to create a guard that will
+LmcRbac is flexible enough to allow you to create custom guard. Let's say we want to create a guard that will
 refuse access based on an IP addresses blacklist.
 
 First create the guard:
@@ -368,7 +368,7 @@ namespace Application\Guard;
 
 use Laminas\Http\Request as HttpRequest;
 use Laminas\Mvc\MvcEvent;
-use ZfcRbac\Guard\AbstractGuard;
+use LmcRbac\Guard\AbstractGuard;
 
 class IpGuard extends AbstractGuard
 {
@@ -410,7 +410,7 @@ class IpGuard extends AbstractGuard
 }
 ```
 
-> Guards must implement `ZfcRbac\Guard\GuardInterface`.
+> Guards must implement `LmcRbac\Guard\GuardInterface`.
 
 By default, guards are listening to the event `MvcEvent::EVENT_ROUTE` with a priority of -5 (you can change the default
 event to listen by overriding the `EVENT_NAME` constant in your guard subclass). However, in this case, we don't
@@ -473,7 +473,7 @@ class IpGuardFactory implements FactoryInterface, MutableCreationOptionsInterfac
 The `MutableCreationOptionsInterface` was introduced in Laminas 2.2, and allows your factories to accept
 options. In fact, in a real use case, you would likely fetched the blacklist from database.
 
-Now, we just need to add the guard to the `guards` option, so that ZfcRbac execute the logic behind this guard. In
+Now, we just need to add the guard to the `guards` option, so that LmcRbac execute the logic behind this guard. In
 your config, add the following code:
 
 ```php

--- a/docs/04. Guards.md
+++ b/docs/04. Guards.md
@@ -13,11 +13,11 @@ the MVC workflow. They allow to quickly unauthorized requests.
 
 Here is a simple workflow without guards:
 
-![Zend Framework workflow without guards](/docs/images/workflow-without-guards.png?raw=true)
+![Laminas workflow without guards](/docs/images/workflow-without-guards.png?raw=true)
 
 And here is a simple workflow with a route guard:
 
-![Zend Framework workflow with guards](/docs/images/workflow-with-guards.png?raw=true)
+![Laminas workflow with guards](/docs/images/workflow-with-guards.png?raw=true)
 
 RouteGuard and ControllerGuard are not aware of permissions but rather only think about "roles". For
 instance, you may want to refuse access to each routes that begin by "admin/*" to all users that do not have the
@@ -80,7 +80,7 @@ return [
 ];
 ```
 
-Because of the way Zend Framework 2 handles config, you can without problem define some rules in one module, and
+Because of the way Laminas handles config, you can without problem define some rules in one module, and
 more rules in another module. All the rules will be automatically merged.
 
 > For your mental health, I recommend you to use either the route guard OR the controller guard, but not both. If
@@ -366,8 +366,8 @@ First create the guard:
 ```php
 namespace Application\Guard;
 
-use Zend\Http\Request as HttpRequest;
-use Zend\Mvc\MvcEvent;
+use Laminas\Http\Request as HttpRequest;
+use Laminas\Mvc\MvcEvent;
 use ZfcRbac\Guard\AbstractGuard;
 
 class IpGuard extends AbstractGuard
@@ -441,9 +441,9 @@ Now, let's create the factory:
 namespace Application\Factory;
 
 use Application\Guard\IpGuard;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\MutableCreationOptionsInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\MutableCreationOptionsInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class IpGuardFactory implements FactoryInterface, MutableCreationOptionsInterface
 {
@@ -470,7 +470,7 @@ class IpGuardFactory implements FactoryInterface, MutableCreationOptionsInterfac
 }
 ```
 
-The `MutableCreationOptionsInterface` was introduced in Zend Framework 2.2, and allows your factories to accept
+The `MutableCreationOptionsInterface` was introduced in Laminas 2.2, and allows your factories to accept
 options. In fact, in a real use case, you would likely fetched the blacklist from database.
 
 Now, we just need to add the guard to the `guards` option, so that ZfcRbac execute the logic behind this guard. In

--- a/docs/04. Guards.md
+++ b/docs/04. Guards.md
@@ -50,7 +50,7 @@ You can change it in ZfcRbac config, as follows:
 use ZfcRbac\Guard\GuardInterface;
 
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'protection_policy' => GuardInterface::POLICY_DENY
     ]
 ];
@@ -72,7 +72,7 @@ All guards must be added in the `guards` subkey:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             // Guards config here!
         ]
@@ -99,7 +99,7 @@ where the key is a route pattern, and value an array of role names:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin'],
@@ -121,7 +121,7 @@ You can also use the wildcard character * for roles:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'home' => ['*']
@@ -137,7 +137,7 @@ Finally, you can also omit the roles array to completly block a route, for maint
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'route_under_construction'
@@ -153,7 +153,7 @@ Note : this last example could be (and should be) written in a more explicit way
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'route_under_construction' => []
@@ -173,7 +173,7 @@ where the key is a route pattern, and value an array of permissions names:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'admin*' => ['admin'],
@@ -193,7 +193,7 @@ to access the ```post/manage``` route. You can also specify an OR condition like
 use ZfcRbac\Guard\GuardInterface;
 
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'post/manage'   => [
@@ -217,7 +217,7 @@ You can also use the wildcard character * for permissions:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'home' => ['*']
@@ -233,7 +233,7 @@ Finally, you can also use an empty array to completly block a route, for mainten
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RoutePermissionsGuard' => [
                 'route_under_construction' => []
@@ -254,7 +254,7 @@ The ControllerGuard allows to protect a controller. You must provide an array of
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\ControllerGuard' => [
                 [
@@ -278,7 +278,7 @@ You can also specify optional actions, so that the rule only apply to one or sev
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\ControllerGuard' => [
                 [
@@ -296,7 +296,7 @@ You can combine a generic rule and a specific action rule for the same controlle
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\ControllerGuard' => [
                 [
@@ -325,7 +325,7 @@ The ControllerPermissionsGuard allows to protect a controller using permissions.
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\ControllerPermissionsGuard' => [
                 [
@@ -423,7 +423,7 @@ following code in your config:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guard_manager' => [
             'factories' => [
                 'Application\Guard\IpGuard' => 'Application\Factory\IpGuardFactory'
@@ -478,7 +478,7 @@ your config, add the following code:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'Application\Guard\IpGuard' => [
                 '87.45.66.46',

--- a/docs/05. Strategies.md
+++ b/docs/05. Strategies.md
@@ -106,15 +106,15 @@ return [
 ## Creating custom strategies
 
 Creating a custom strategy is rather easy. Let's say we want to create a strategy that integrates with
-the [ApiProblem](https://github.com/zfcampus/zf-api-problem) Zend Framework 2 module:
+the [ApiProblem](https://github.com/laminas-api-tools/api-tools-api-problem) Laminas module:
 
 ```php
 namespace Application\View\Strategy;
 
-use Zend\Http\Response as HttpResponse;
-use Zend\Mvc\MvcEvent;
-use ZF\ApiProblem\ApiProblem;
-use ZF\ApiProblem\ApiProblemResponse;
+use Laminas\Http\Response as HttpResponse;
+use Laminas\Mvc\MvcEvent;
+use Laminas\ApiTools\ApiProblem\ApiProblem;
+use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
 use ZfcRbac\View\Strategy\AbstractStrategy;
 use ZfcRbac\Exception\UnauthorizedExceptionInterface;
 

--- a/docs/05. Strategies.md
+++ b/docs/05. Strategies.md
@@ -45,7 +45,7 @@ public function onBootstrap(EventInterface $e)
     $t = $e->getTarget();
 
     $t->getEventManager()->attach(
-        $t->getServiceManager()->get('ZfcRbac\View\Strategy\RedirectStrategy')
+        $t->getServiceManager()->get('LmcRbac\View\Strategy\RedirectStrategy')
     );
 }
 ```
@@ -84,7 +84,7 @@ public function onBootstrap(EventInterface $e)
     $t = $e->getTarget();
 
     $t->getEventManager()->attach(
-        $t->getServiceManager()->get('ZfcRbac\View\Strategy\UnauthorizedStrategy')
+        $t->getServiceManager()->get('LmcRbac\View\Strategy\UnauthorizedStrategy')
     );
 }
 ```
@@ -101,7 +101,7 @@ return [
 ];
 ```
 
-> By default, ZfcRbac uses a template called `error/403`.
+> By default, LmcRbac uses a template called `error/403`.
 
 ## Creating custom strategies
 
@@ -115,8 +115,8 @@ use Laminas\Http\Response as HttpResponse;
 use Laminas\Mvc\MvcEvent;
 use Laminas\ApiTools\ApiProblem\ApiProblem;
 use Laminas\ApiTools\ApiProblem\ApiProblemResponse;
-use ZfcRbac\View\Strategy\AbstractStrategy;
-use ZfcRbac\Exception\UnauthorizedExceptionInterface;
+use LmcRbac\View\Strategy\AbstractStrategy;
+use LmcRbac\Exception\UnauthorizedExceptionInterface;
 
 class ApiProblemStrategy extends AbstractStrategy
 {

--- a/docs/05. Strategies.md
+++ b/docs/05. Strategies.md
@@ -9,11 +9,11 @@ In this section, you will learn:
 ## What are strategies?
 
 A strategy is an object that listens to the `MvcEvent::EVENT_DISPATCH_ERROR` event. It is used to describe what
-happens when an access to a resource is unauthorized by ZfcRbac.
+happens when an access to a resource is unauthorized by LmcRbac.
 
-ZfcRbac strategies all check if an `ZfcRbac\Exception\UnauthorizedExceptionInterface` has been thrown.
+LmcRbac strategies all check if an `LmcRbac\Exception\UnauthorizedExceptionInterface` has been thrown.
 
-By default, ZfcRbac does not register any strategy for you. The best place to register it is in your `onBootstrap`
+By default, LmcRbac does not register any strategy for you. The best place to register it is in your `onBootstrap`
 method of the `Module.php` class:
 
 ```php
@@ -23,14 +23,14 @@ public function onBootstrap(MvcEvent $event)
     $sm = $app->getServiceManager();
     $em = $app->getEventManager();
 
-    $listener = $sm->get(\ZfcRbac\View\Strategy\RedirectStrategy::class);
+    $listener = $sm->get(\LmcRbac\View\Strategy\RedirectStrategy::class);
     $listener->attach($em);
 }
 ```
 
 ## Built-in strategies
 
-ZfcRbac comes with two built-in strategies: `RedirectStrategy` and `UnauthorizedStrategy`.
+LmcRbac comes with two built-in strategies: `RedirectStrategy` and `UnauthorizedStrategy`.
 
 ### RedirectStrategy
 
@@ -54,7 +54,7 @@ You can configure the strategy using the `redirect_strategy` subkey:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'redirect_strategy' => [
             'redirect_when_connected'        => true,
             'redirect_to_route_connected'    => 'home',
@@ -93,7 +93,7 @@ You can configure the strategy using the `unauthorized_strategy` subkey:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'unauthorized_strategy' => [
             'template' => 'error/custom-403'
         ],

--- a/docs/06. Using the Authorization Service.md
+++ b/docs/06. Using the Authorization Service.md
@@ -12,8 +12,8 @@ To automatically inject the authorization service into your classes, you can imp
 ```php
 namespace YourModule;
 
-use ZfcRbac\Service\AuthorizationServiceAwareInterface;
-use ZfcRbac\Service\AuthorizationServiceAwareTrait;
+use LmcRbac\Service\AuthorizationServiceAwareInterface;
+use LmcRbac\Service\AuthorizationServiceAwareTrait;
 
 class MyClass implements AuthorizationServiceAwareInterface
 {
@@ -41,7 +41,7 @@ class Module
     {
         return [
             'initializers' => [
-                'ZfcRbac\Initializer\AuthorizationServiceInitializer'
+                'LmcRbac\Initializer\AuthorizationServiceInitializer'
             ]
         ];
     }
@@ -52,7 +52,7 @@ class Module
 
 ### Using delegator factory
 
-ZfcRbac is shipped with a `ZfcRbac\Factory\AuthorizationServiceDelegatorFactory` [delegator factory]
+LmcRbac is shipped with a `LmcRbac\Factory\AuthorizationServiceDelegatorFactory` [delegator factory]
 (http://framework.zend.com/manual/2.3/en/modules/zend.service-manager.delegator-factories.html)
 to automatically inject the authorization service into your classes.
 
@@ -73,7 +73,7 @@ class Module
             ],
             'delegators' => [
                 'Application\Service\MyClass' => [
-                     'ZfcRbac\Factory\AuthorizationServiceDelegatorFactory',
+                     'LmcRbac\Factory\AuthorizationServiceDelegatorFactory',
                      // eventually add more delegators here
                 ],
             ],
@@ -87,7 +87,7 @@ class Module
 ### Using Factories
 
 You can inject the AuthorizationService in your factories by using Zend's ServiceManager. The AuthorizationService
-is known to the ServiceManager as `\ZfcRbac\Service\AuthorizationService::class`. Here is a classic example for injecting
+is known to the ServiceManager as `\LmcRbac\Service\AuthorizationService::class`. Here is a classic example for injecting
 the AuthorizationService:
 
 *YourModule/Module.php*
@@ -102,7 +102,7 @@ class Module
         return [
             'factories' => [
                  'MyService' => function($sm) {
-                     $authService = $sm->get(\ZfcRbac\Service\AuthorizationService::class);
+                     $authService = $sm->get(\LmcRbac\Service\AuthorizationService::class);
                      return new MyService($authService);
                  }
             ]
@@ -159,7 +159,7 @@ by adding this to your `module.config.php` file:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'assertion_manager' => [
             'factories' => [
                 'MyAssertion' => 'MyAssertionFactory'
@@ -177,7 +177,7 @@ adding this to your `module.config.php` file:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'assertion_map' => [
             'myPermission' => 'myAssertion'
         ]
@@ -202,7 +202,7 @@ provided by the assertion map.
 
 ### Checking permissions in a controller or in a view
 
-ZfcRbac comes with both a controller plugin and a view helper to check permissions.
+LmcRbac comes with both a controller plugin and a view helper to check permissions.
 
 In a controller :
 

--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -753,7 +753,7 @@ To use the authentication service from ZfcUser, just add the following alias in 
 return [
     'service_manager' => [
         'aliases' => [
-            'Zend\Authentication\AuthenticationService' => 'zfcuser_auth_service'
+            'Laminas\Authentication\AuthenticationService' => 'zfcuser_auth_service'
         ]
     ]
 ];

--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -10,10 +10,10 @@ any other recipe you'd like to add, please open an issue!
 - [A Real World Application Part 3 - But Admins can delete everything](/docs/07.%20Cookbook.md#a-real-world-application-part-3---admins-can-delete-everything)
 - [A Real World Application Part 4 - Only admins have the menu item for managing the posts]
     (/docs/07.%20Cookbook.md#a-real-world-application-part-4---checking-permissions-in-the-view)
-- [Using LmcRbac with Doctrine ORM](/docs/07.%20Cookbook.md#using-zfcrbac-with-doctrine-orm)
+- [Using LmcRbac with Doctrine ORM](/docs/07.%20Cookbook.md#using-LmcRbac-with-doctrine-orm)
     - [How to deal with roles with lot of permissions?](/docs/07.%20Cookbook.md#how-to-deal-with-roles-with-lot-of-permissions)
-- [Using LmcRbac and ZF2 Assetic](/docs/07.%20Cookbook.md#using-zfcrbac-and-zf2-assetic)
-- [Using LmcRbac and ZfcUser](/docs/07.%20Cookbook.md#using-zfcrbac-and-zfcuser)
+- [Using LmcRbac and ZF2 Assetic](/docs/07.%20Cookbook.md#using-LmcRbac-and-zf2-assetic)
+- [Using LmcRbac and ZfcUser](/docs/07.%20Cookbook.md#using-LmcRbac-and-zfcuser)
 
 ## A Real World Application
 
@@ -130,7 +130,7 @@ Assuming the application example above we can easily use LmcRbac to protect our 
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'post/delete' => ['admin']
             ]
         ]
@@ -162,7 +162,7 @@ permissions before doing anything wrong. So let's modify our previously created 
 
 ```php
 use Doctrine\Common\Persistence\ObjectManager;
-use ZfcRbac\Service\AuthorizationService;
+use LmcRbac\Service\AuthorizationService;
 
 class PostService
 {
@@ -206,7 +206,7 @@ class Module
                  'PostService' => function($sm) {
                      return new PostService(
                          $sm->get('doctrine.entitymanager.orm_default'),
-                         $sm->get(\ZfcRbac\Service\AuthorizationService::class) // This is new!
+                         $sm->get(\LmcRbac\Service\AuthorizationService::class) // This is new!
                      );
                  }
             ]
@@ -279,7 +279,7 @@ You can quickly unauthorized access to all admin routes using the following guar
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin']
             ]
         ]
@@ -328,7 +328,7 @@ As we can see, we check within our Service if the User of our Application is all
 against the `deletePost` permission. Now how can we achieve that only a user who is the owner of the Post to be able to
 delete his own post, but other users can't? We do not want to change our Service with more complex logic because this
 is not the task of such service. The Permission-System should handle this. And we can, for this we have the
- [`AssertionPluginManager`](/src/ZfcRbac/Assertion/AssertionPluginManager.php) and here is how to do it:
+ [`AssertionPluginManager`](/src/LmcRbac/Assertion/AssertionPluginManager.php) and here is how to do it:
 
 First of all things we need to write an Assertion. The Assertion will return a boolean statement about the current
 identity being the owner of the post.
@@ -336,8 +336,8 @@ identity being the owner of the post.
 ```php
 namespace Your\Namespace;
 
-use ZfcRbac\Assertion\AssertionInterface;
-use ZfcRbac\Service\AuthorizationService;
+use LmcRbac\Assertion\AssertionInterface;
+use LmcRbac\Service\AuthorizationService;
 
 class MustBeAuthorAssertion implements AssertionInterface
 {
@@ -457,8 +457,8 @@ The assertion must therefore be modified like this:
 ```php
 namespace Your\Namespace;
 
-use ZfcRbac\Assertion\AssertionInterface;
-use ZfcRbac\Service\AuthorizationService;
+use LmcRbac\Assertion\AssertionInterface;
+use LmcRbac\Service\AuthorizationService;
 
 class MustBeAuthorAssertion implements AssertionInterface
 {
@@ -514,13 +514,13 @@ You can even protect your menu item regarding a role, by using the ```hasRole```
 
 In this last example, the menu item will be hidden for users who don't have the ```admin``` role.
 
-## Using ZfcRbac with Doctrine ORM
+## Using LmcRbac with Doctrine ORM
 
-First your User entity class must implement `ZfcRbac\Identity\IdentityInterface` :
+First your User entity class must implement `LmcRbac\Identity\IdentityInterface` :
 
 ```php
 use ZfcUser\Entity\User as ZfcUserEntity;
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Identity\IdentityInterface;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -665,13 +665,13 @@ And the last step is to create Permission entity class which is a very simple en
 
 You can find all entity example in this folder : [Example](/data)
 
-You need one more configuration step. Indeed, how can the RoleProvider retrieve your role and permissions ? For this you need to configure `ZfcRbac\Role\ObjectRepositoryRoleProvider` in your `lmc_rbac.global.php` file :
+You need one more configuration step. Indeed, how can the RoleProvider retrieve your role and permissions ? For this you need to configure `LmcRbac\Role\ObjectRepositoryRoleProvider` in your `lmc_rbac.global.php` file :
 ```php
         /**
          * Configuration for role provider
          */
         'role_provider' => [
-            \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => [
+            \LmcRbac\Role\ObjectRepositoryRoleProvider::class => [
                 'object_manager'     => 'doctrine.entitymanager.orm_default', // alias for doctrine ObjectManager
                 'class_name'         => 'User\Entity\HierarchicalRole', // FQCN for your role entity class
                 'role_name_property' => 'name', // Name to show
@@ -679,7 +679,7 @@ You need one more configuration step. Indeed, how can the RoleProvider retrieve 
         ],
 ```
 
-Using DoctrineORM with ZfcRbac is very simple. You need to be aware from performances where there is a lot of permissions for roles.
+Using DoctrineORM with LmcRbac is very simple. You need to be aware from performances where there is a lot of permissions for roles.
 
 ## How to deal with roles with lot of permissions?
 
@@ -730,22 +730,22 @@ public function hasPermission($permission)
 
 > NOTE: This is only supported starting from Doctrine ORM 2.5!
 
-## Using ZfcRbac and ZF2 Assetic
+## Using LmcRbac and ZF2 Assetic
 
-To use [Assetic](https://github.com/widmogrod/zf2-assetic-module) with ZfcRbac guards, you should modify your
+To use [Assetic](https://github.com/widmogrod/zf2-assetic-module) with LmcRbac guards, you should modify your
 `module.config.php` using the following configuration:
 
 ```php
 return [
     'assetic_configuration' => [
         'acceptableErrors' => [
-            \ZfcRbac\Guard\GuardInterface::GUARD_UNAUTHORIZED
+            \LmcRbac\Guard\GuardInterface::GUARD_UNAUTHORIZED
         ]
     ]
 ];
 ```
 
-## Using ZfcRbac and ZfcUser
+## Using LmcRbac and ZfcUser
 
 To use the authentication service from ZfcUser, just add the following alias in your application.config.php:
 
@@ -765,7 +765,7 @@ Finally add the ZfcUser routes to your `guards`:
 return [
     'lmc_rbac' => [
         'guards' => [
-            'ZfcRbac\Guard\RouteGuard' => [
+            'LmcRbac\Guard\RouteGuard' => [
                 'zfcuser/login'    => ['guest'],
                 'zfcuser/register' => ['guest'], // required if registration is enabled
                 'zfcuser*'         => ['user'] // includes logout, changepassword and changeemail

--- a/docs/07. Cookbook.md
+++ b/docs/07. Cookbook.md
@@ -1,6 +1,6 @@
 # Cookbook
 
-This section will help you to further understand how ZfcRbac works by providing more concrete examples. If you have
+This section will help you to further understand how LmcRbac works by providing more concrete examples. If you have
 any other recipe you'd like to add, please open an issue!
 
 - [A Real World Application](/docs/07.%20Cookbook.md#a-real-world-application)
@@ -10,10 +10,10 @@ any other recipe you'd like to add, please open an issue!
 - [A Real World Application Part 3 - But Admins can delete everything](/docs/07.%20Cookbook.md#a-real-world-application-part-3---admins-can-delete-everything)
 - [A Real World Application Part 4 - Only admins have the menu item for managing the posts]
     (/docs/07.%20Cookbook.md#a-real-world-application-part-4---checking-permissions-in-the-view)
-- [Using ZfcRbac with Doctrine ORM](/docs/07.%20Cookbook.md#using-zfcrbac-with-doctrine-orm)
+- [Using LmcRbac with Doctrine ORM](/docs/07.%20Cookbook.md#using-zfcrbac-with-doctrine-orm)
     - [How to deal with roles with lot of permissions?](/docs/07.%20Cookbook.md#how-to-deal-with-roles-with-lot-of-permissions)
-- [Using ZfcRbac and ZF2 Assetic](/docs/07.%20Cookbook.md#using-zfcrbac-and-zf2-assetic)
-- [Using ZfcRbac and ZfcUser](/docs/07.%20Cookbook.md#using-zfcrbac-and-zfcuser)
+- [Using LmcRbac and ZF2 Assetic](/docs/07.%20Cookbook.md#using-zfcrbac-and-zf2-assetic)
+- [Using LmcRbac and ZfcUser](/docs/07.%20Cookbook.md#using-zfcrbac-and-zfcuser)
 
 ## A Real World Application
 
@@ -124,11 +124,11 @@ This leaves your application open for some undesired side-effects.
 As a best practice you should protect all your services or controllers by injecting the authorization service.
 But let's go step by step:
 
-Assuming the application example above we can easily use ZfcRbac to protect our route using the following guard:
+Assuming the application example above we can easily use LmcRbac to protect our route using the following guard:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'post/delete' => ['admin']
@@ -277,7 +277,7 @@ You can quickly unauthorized access to all admin routes using the following guar
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'admin*' => ['admin']
@@ -371,7 +371,7 @@ called `assertion_map`. In this map we glue `assertions` and `permissions` toget
 ```php
 // module.config.php or wherever you configure your RBAC stuff
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'assertion_map' => [
             'deletePost' => 'Your\Namespace\MustBeAuthorAssertion'
         ]
@@ -387,7 +387,7 @@ shown below:
 ```php
 // module.config.php or wherever you configure your RBAC stuff
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         // ... other rbac stuff
         'assertion_manager' => [
             'factories' => [
@@ -665,7 +665,7 @@ And the last step is to create Permission entity class which is a very simple en
 
 You can find all entity example in this folder : [Example](/data)
 
-You need one more configuration step. Indeed, how can the RoleProvider retrieve your role and permissions ? For this you need to configure `ZfcRbac\Role\ObjectRepositoryRoleProvider` in your `zfc_rbac.global.php` file :
+You need one more configuration step. Indeed, how can the RoleProvider retrieve your role and permissions ? For this you need to configure `ZfcRbac\Role\ObjectRepositoryRoleProvider` in your `lmc_rbac.global.php` file :
 ```php
         /**
          * Configuration for role provider
@@ -763,7 +763,7 @@ Finally add the ZfcUser routes to your `guards`:
 
 ```php
 return [
-    'zfc_rbac' => [
+    'lmc_rbac' => [
         'guards' => [
             'ZfcRbac\Guard\RouteGuard' => [
                 'zfcuser/login'    => ['guest'],

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-_Up-to-date with version 2.3.* of ZfcRbac_
+_Up-to-date with version 2.3.* of LmcRbac_
 
 Welcome to the official ZfcRbac documentation. This documentation will help you to quickly understand how to use
 and extend ZfcRbac.
@@ -8,7 +8,7 @@ If you are looking for some information that is not listed in the documentation,
 1. [Introduction](/docs/01. Introduction.md)
    1. [Why should I use an authorization module?](/docs/01. Introduction.md#why-should-i-use-an-authorization-module)
    2. [What is the Rbac model?](/docs/01. Introduction.md#what-is-the-rbac-model)
-   3. [How can I integrate ZfcRbac into my application?](/docs/01. Introduction.md#how-can-i-integrate-zfcrbac-into-my-application)
+   3. [How can I integrate LmcRbac into my application?](/docs/01. Introduction.md#how-can-i-integrate-zfcrbac-into-my-application)
 
 2. [Quick Start](/docs/02. Quick Start.md)
    1. [Specifying an identity provider](/docs/02. Quick Start.md#specifying-an-identity-provider)
@@ -46,7 +46,7 @@ If you are looking for some information that is not listed in the documentation,
 7. [Cookbook](/docs/07. Cookbook.md)
    1. [A real world example](/docs/07. Cookbook.md#a-real-world-application)
    2. [Best practices](/docs/07. Cookbook.md#best-practices)
-   3. [Using ZfcRbac with Doctrine ORM](/docs/07. Cookbook.md#using-zfcrbac-with-doctrine-orm)
+   3. [Using LmcRbac with Doctrine ORM](/docs/07. Cookbook.md#using-zfcrbac-with-doctrine-orm)
    4. [How to deal with roles with lot of permissions?](/docs/07. Cookbook.md#how-to-deal-with-roles-with-lot-of-permissions)
-   5. [Using ZfcRbac and ZF2 Assetic](/docs/07. Cookbook.md#using-zfcrbac-and-zf2-assetic)
-   6. [Using ZfcRbac and ZfcUser](/docs/07. Cookbook.md#using-zfcrbac-and-zfcuser)
+   5. [Using LmcRbac and ZF2 Assetic](/docs/07. Cookbook.md#using-zfcrbac-and-zf2-assetic)
+   6. [Using LmcRbac and ZfcUser](/docs/07. Cookbook.md#using-zfcrbac-and-zfcuser)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,7 @@
         processIsolation="false"
         backupGlobals="false"
         >
-    <testsuite name="ZfcRbac tests">
+    <testsuite name="LmcRbac tests">
         <directory>./test</directory>
     </testsuite>
     <filter>

--- a/src/Assertion/AssertionContainer.php
+++ b/src/Assertion/AssertionContainer.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 
 namespace ZfcRbac\Assertion;
 
-use Zend\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\AbstractPluginManager;
 
 /**
  * Plugin manager to create assertions

--- a/src/Assertion/AssertionContainer.php
+++ b/src/Assertion/AssertionContainer.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Assertion;
+namespace LmcRbac\Assertion;
 
 use Laminas\ServiceManager\AbstractPluginManager;
 

--- a/src/Assertion/AssertionContainerInterface.php
+++ b/src/Assertion/AssertionContainerInterface.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Assertion;
+namespace LmcRbac\Assertion;
 
 use Psr\Container\ContainerInterface;
 

--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Assertion;
+namespace LmcRbac\Assertion;
 
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Identity\IdentityInterface;
 
 /**
  * Interface that you can implement for dynamic assertions

--- a/src/Assertion/AssertionSet.php
+++ b/src/Assertion/AssertionSet.php
@@ -19,10 +19,10 @@ declare(strict_types=1);
  * and is licensed under the MIT license.
  */
 
-namespace ZfcRbac\Assertion;
+namespace LmcRbac\Assertion;
 
-use ZfcRbac\Exception;
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Exception;
+use LmcRbac\Identity\IdentityInterface;
 
 final class AssertionSet implements AssertionInterface
 {
@@ -88,7 +88,7 @@ final class AssertionSet implements AssertionInterface
                     break;
                 default:
                     throw new Exception\InvalidArgumentException(sprintf(
-                        'Assertion must be callable, string, array or implement ZfcRbac\Assertion\AssertionInterface, "%s" given',
+                        'Assertion must be callable, string, array or implement LmcRbac\Assertion\AssertionInterface, "%s" given',
                         is_object($assertion) ? get_class($assertion) : gettype($assertion)
                     ));
             }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -46,7 +46,7 @@ final class ConfigProvider
                 \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => \ZfcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
                 \ZfcRbac\Service\AuthorizationServiceInterface::class => \ZfcRbac\Container\AuthorizationServiceFactory::class,
                 \ZfcRbac\Service\RoleServiceInterface::class => \ZfcRbac\Container\RoleServiceFactory::class,
-                \ZfcRbac\Rbac::class => \Zend\ServiceManager\Factory\InvokableFactory::class,
+                \ZfcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac;
+namespace LmcRbac;
 
 /**
- * The configuration provider for the ZfcRbac module
+ * The configuration provider for the LmcRbac module
  *
  * @see https://docs.laminas.dev/laminas-component-installer/
  */
@@ -40,13 +40,13 @@ final class ConfigProvider
     {
         return [
             'factories' => [
-                \ZfcRbac\Assertion\AssertionContainerInterface::class => \ZfcRbac\Container\AssertionContainerFactory::class,
-                \ZfcRbac\Options\ModuleOptions::class => \ZfcRbac\Container\ModuleOptionsFactory::class,
-                \ZfcRbac\Role\InMemoryRoleProvider::class => \ZfcRbac\Container\InMemoryRoleProviderFactory::class,
-                \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => \ZfcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
-                \ZfcRbac\Service\AuthorizationServiceInterface::class => \ZfcRbac\Container\AuthorizationServiceFactory::class,
-                \ZfcRbac\Service\RoleServiceInterface::class => \ZfcRbac\Container\RoleServiceFactory::class,
-                \ZfcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
+                \LmcRbac\Assertion\AssertionContainerInterface::class => \LmcRbac\Container\AssertionContainerFactory::class,
+                \LmcRbac\Options\ModuleOptions::class => \LmcRbac\Container\ModuleOptionsFactory::class,
+                \LmcRbac\Role\InMemoryRoleProvider::class => \LmcRbac\Container\InMemoryRoleProviderFactory::class,
+                \LmcRbac\Role\ObjectRepositoryRoleProvider::class => \LmcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
+                \LmcRbac\Service\AuthorizationServiceInterface::class => \LmcRbac\Container\AuthorizationServiceFactory::class,
+                \LmcRbac\Service\RoleServiceInterface::class => \LmcRbac\Container\RoleServiceFactory::class,
+                \LmcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
             ],
         ];
     }

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -32,7 +32,7 @@ final class ConfigProvider
     {
         return [
             'dependencies' => $this->getDependencyConfig(),
-            'zfc_rbac' => $this->getModuleConfig(),
+            'lmc_rbac' => $this->getModuleConfig(),
         ];
     }
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -24,7 +24,7 @@ namespace ZfcRbac;
 /**
  * The configuration provider for the ZfcRbac module
  *
- * @see https://docs.zendframework.com/zend-component-installer/
+ * @see https://docs.laminas.dev/laminas-component-installer/
  */
 final class ConfigProvider
 {

--- a/src/Container/AssertionContainerFactory.php
+++ b/src/Container/AssertionContainerFactory.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Assertion\AssertionContainer;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory to create a assertion plugin manager

--- a/src/Container/AssertionContainerFactory.php
+++ b/src/Container/AssertionContainerFactory.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Assertion\AssertionContainer;
+use LmcRbac\Assertion\AssertionContainer;
 
 /**
  * Factory to create a assertion plugin manager

--- a/src/Container/AssertionContainerFactory.php
+++ b/src/Container/AssertionContainerFactory.php
@@ -34,7 +34,7 @@ final class AssertionContainerFactory
 {
     public function __invoke(ContainerInterface $container): AssertionContainer
     {
-        $config = $container->get('config')['zfc_rbac']['assertion_manager'];
+        $config = $container->get('config')['lmc_rbac']['assertion_manager'];
 
         return new AssertionContainer($container, $config);
     }

--- a/src/Container/AuthorizationServiceFactory.php
+++ b/src/Container/AuthorizationServiceFactory.php
@@ -21,12 +21,12 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Assertion\AssertionContainerInterface;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Rbac;
 use LmcRbac\Service\AuthorizationService;
 use LmcRbac\Service\RoleServiceInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory to create the authorization service

--- a/src/Container/AuthorizationServiceFactory.php
+++ b/src/Container/AuthorizationServiceFactory.php
@@ -19,14 +19,14 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Assertion\AssertionContainerInterface;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Rbac;
-use ZfcRbac\Service\AuthorizationService;
-use ZfcRbac\Service\RoleServiceInterface;
+use LmcRbac\Assertion\AssertionContainerInterface;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Rbac;
+use LmcRbac\Service\AuthorizationService;
+use LmcRbac\Service\RoleServiceInterface;
 
 /**
  * Factory to create the authorization service

--- a/src/Container/InMemoryRoleProviderFactory.php
+++ b/src/Container/InMemoryRoleProviderFactory.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\InMemoryRoleProvider;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory used to create an in memory role provider

--- a/src/Container/InMemoryRoleProviderFactory.php
+++ b/src/Container/InMemoryRoleProviderFactory.php
@@ -19,11 +19,11 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\InMemoryRoleProvider;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\InMemoryRoleProvider;
 
 /**
  * Factory used to create an in memory role provider

--- a/src/Container/ModuleOptionsFactory.php
+++ b/src/Container/ModuleOptionsFactory.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Options\ModuleOptions;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory for the module options

--- a/src/Container/ModuleOptionsFactory.php
+++ b/src/Container/ModuleOptionsFactory.php
@@ -34,6 +34,6 @@ final class ModuleOptionsFactory
 {
     public function __invoke(ContainerInterface $container): ModuleOptions
     {
-        return new ModuleOptions($container->get('config')['zfc_rbac']);
+        return new ModuleOptions($container->get('config')['lmc_rbac']);
     }
 }

--- a/src/Container/ModuleOptionsFactory.php
+++ b/src/Container/ModuleOptionsFactory.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Options\ModuleOptions;
+use LmcRbac\Options\ModuleOptions;
 
 /**
  * Factory for the module options

--- a/src/Container/ObjectRepositoryRoleProviderFactory.php
+++ b/src/Container/ObjectRepositoryRoleProviderFactory.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Exception;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\ObjectRepositoryRoleProvider;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory used to create an object repository role provider

--- a/src/Container/ObjectRepositoryRoleProviderFactory.php
+++ b/src/Container/ObjectRepositoryRoleProviderFactory.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Exception;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\ObjectRepositoryRoleProvider;
+use LmcRbac\Exception;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\ObjectRepositoryRoleProvider;
 
 /**
  * Factory used to create an object repository role provider
@@ -57,7 +57,7 @@ final class ObjectRepositoryRoleProviderFactory
         }
 
         throw new Exception\RuntimeException(
-            'No object repository was found while creating the ZfcRbac object repository role provider. Are
+            'No object repository was found while creating the LmcRbac object repository role provider. Are
              you sure you specified either the "object_repository" option or "object_manager"/"class_name" options?'
         );
     }

--- a/src/Container/RoleServiceFactory.php
+++ b/src/Container/RoleServiceFactory.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 
 namespace LmcRbac\Container;
 
-use Psr\Container\ContainerInterface;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\RoleProviderInterface;
 use LmcRbac\Service\RoleService;
+use Psr\Container\ContainerInterface;
 
 /**
  * Factory to create the role service

--- a/src/Container/RoleServiceFactory.php
+++ b/src/Container/RoleServiceFactory.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Container;
+namespace LmcRbac\Container;
 
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\RoleProviderInterface;
-use ZfcRbac\Service\RoleService;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\RoleProviderInterface;
+use LmcRbac\Service\RoleService;
 
 /**
  * Factory to create the role service

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 /**
- * Base exception interface for ZfcRbac
+ * Base exception interface for LmcRbac
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 use InvalidArgumentException as BaseInvalidArgumentException;
 

--- a/src/Exception/RoleNotFoundException.php
+++ b/src/Exception/RoleNotFoundException.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 use RuntimeException as BaseRuntimeException;
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 use RuntimeException as BaseRuntimeException;
 

--- a/src/Exception/UnauthorizedException.php
+++ b/src/Exception/UnauthorizedException.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 use RuntimeException as BaseRuntimeException;
 

--- a/src/Exception/UnauthorizedExceptionInterface.php
+++ b/src/Exception/UnauthorizedExceptionInterface.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Exception;
+namespace LmcRbac\Exception;
 
 /**
  * Interface for an unauthorized exception

--- a/src/Identity/IdentityInterface.php
+++ b/src/Identity/IdentityInterface.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Identity;
+namespace LmcRbac\Identity;
 
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 /**
  * Interface for an identity

--- a/src/Module.php
+++ b/src/Module.php
@@ -32,7 +32,7 @@ final class Module
 
         return [
             'service_manager' => $provider->getDependencyConfig(),
-            'zfc_rbac' => $provider->getModuleConfig(),
+            'lmc_rbac' => $provider->getModuleConfig(),
         ];
     }
 }

--- a/src/Module.php
+++ b/src/Module.php
@@ -24,7 +24,7 @@ namespace ZfcRbac;
 final class Module
 {
     /**
-     * Return default ZfcRbac configuration for zend-mvc applications.
+     * Return default ZfcRbac configuration for laminas-mvc applications.
      */
     public function getConfig(): array
     {

--- a/src/Module.php
+++ b/src/Module.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac;
+namespace LmcRbac;
 
 final class Module
 {
     /**
-     * Return default ZfcRbac configuration for laminas-mvc applications.
+     * Return default LmcRbac configuration for laminas-mvc applications.
      */
     public function getConfig(): array
     {

--- a/src/Options/ModuleOptions.php
+++ b/src/Options/ModuleOptions.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
 
 namespace ZfcRbac\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Options for ZfcRbac module

--- a/src/Options/ModuleOptions.php
+++ b/src/Options/ModuleOptions.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Options;
+namespace LmcRbac\Options;
 
 use Laminas\Stdlib\AbstractOptions;
 
 /**
- * Options for ZfcRbac module
+ * Options for LmcRbac module
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>
  * @licence MIT

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace LmcRbac;
 
 use Generator;
-use Traversable;
 use LmcRbac\Role\HierarchicalRoleInterface;
 use LmcRbac\Role\RoleInterface;
+use Traversable;
 
 /**
  * Rbac object. It is used to check a permission against roles

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac;
+namespace LmcRbac;
 
 use Generator;
 use Traversable;
-use ZfcRbac\Role\HierarchicalRoleInterface;
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\HierarchicalRoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 /**
  * Rbac object. It is used to check a permission against roles
@@ -49,7 +49,7 @@ class Rbac
         }
 
         foreach ($this->flattenRoles($roles) as $role) {
-            /* @var \ZfcRbac\Role\RoleInterface $role */
+            /* @var \LmcRbac\Role\RoleInterface $role */
             if ($role->hasPermission($permission)) {
                 return true;
             }

--- a/src/Role/HierarchicalRole.php
+++ b/src/Role/HierarchicalRole.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * Simple implementation for a hierarchical role

--- a/src/Role/HierarchicalRoleInterface.php
+++ b/src/Role/HierarchicalRoleInterface.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * Interface for a hierarchical role

--- a/src/Role/InMemoryRoleProvider.php
+++ b/src/Role/InMemoryRoleProvider.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * Simple role providers that store them in memory (ideal for small websites)

--- a/src/Role/ObjectRepositoryRoleProvider.php
+++ b/src/Role/ObjectRepositoryRoleProvider.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 use Doctrine\Common\Persistence\ObjectRepository;
-use ZfcRbac\Exception\RoleNotFoundException;
+use LmcRbac\Exception\RoleNotFoundException;
 
 /**
  * Role provider that uses Doctrine object repository to fetch roles

--- a/src/Role/Role.php
+++ b/src/Role/Role.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * Simple implementation for a role without hierarchy

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * Interface for a flat role

--- a/src/Role/RoleProviderInterface.php
+++ b/src/Role/RoleProviderInterface.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Role;
+namespace LmcRbac\Role;
 
 /**
  * A role provider is an object that collect roles from string and convert them to RoleInterface instances
  *
- * Data can come from anywhere. ZfcRbac is bundled with two providers that allow to load roles from database
+ * Data can come from anywhere. LmcRbac is bundled with two providers that allow to load roles from database
  * or from memory
  *
  * @author  Michaël Gallego <mic.gallego@gmail.com>

--- a/src/Service/AuthorizationService.php
+++ b/src/Service/AuthorizationService.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Service;
+namespace LmcRbac\Service;
 
-use ZfcRbac\Assertion\AssertionContainerInterface;
-use ZfcRbac\Assertion\AssertionSet;
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Rbac;
+use LmcRbac\Assertion\AssertionContainerInterface;
+use LmcRbac\Assertion\AssertionSet;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbac\Rbac;
 
 /**
  * Authorization service is a simple service that internally uses Rbac to check if identity is

--- a/src/Service/AuthorizationServiceInterface.php
+++ b/src/Service/AuthorizationServiceInterface.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Service;
+namespace LmcRbac\Service;
 
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Identity\IdentityInterface;
 
 /**
  * Minimal interface for an authorization service

--- a/src/Service/RoleService.php
+++ b/src/Service/RoleService.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 
 namespace LmcRbac\Service;
 
-use Traversable;
 use LmcRbac\Identity\IdentityInterface;
 use LmcRbac\Role\RoleInterface;
 use LmcRbac\Role\RoleProviderInterface;
+use Traversable;
 
 /**
  * Role service

--- a/src/Service/RoleService.php
+++ b/src/Service/RoleService.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Service;
+namespace LmcRbac\Service;
 
 use Traversable;
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Role\RoleInterface;
-use ZfcRbac\Role\RoleProviderInterface;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleProviderInterface;
 
 /**
  * Role service

--- a/src/Service/RoleServiceInterface.php
+++ b/src/Service/RoleServiceInterface.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbac\Service;
+namespace LmcRbac\Service;
 
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbac\Role\RoleInterface;
 
 /**
  * Role service

--- a/test/Assertion/AssertionContainerTest.php
+++ b/test/Assertion/AssertionContainerTest.php
@@ -24,7 +24,7 @@ namespace ZfcRbacTest\Assertion;
 use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
-use Zend\ServiceManager\Factory\InvokableFactory;
+use Laminas\ServiceManager\Factory\InvokableFactory;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Assertion\AssertionInterface;
 use ZfcRbacTest\Asset\SimpleAssertion;

--- a/test/Assertion/AssertionContainerTest.php
+++ b/test/Assertion/AssertionContainerTest.php
@@ -19,18 +19,18 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Assertion;
+namespace LmcRbacTest\Assertion;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
-use ZfcRbac\Assertion\AssertionContainer;
-use ZfcRbac\Assertion\AssertionInterface;
-use ZfcRbacTest\Asset\SimpleAssertion;
+use LmcRbac\Assertion\AssertionContainer;
+use LmcRbac\Assertion\AssertionInterface;
+use LmcRbacTest\Asset\SimpleAssertion;
 
 /**
- * @covers \ZfcRbac\Assertion\AssertionContainer
+ * @covers \LmcRbac\Assertion\AssertionContainer
  */
 class AssertionContainerTest extends TestCase
 {

--- a/test/Assertion/AssertionContainerTest.php
+++ b/test/Assertion/AssertionContainerTest.php
@@ -23,11 +23,11 @@ namespace LmcRbacTest\Assertion;
 
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\InvokableFactory;
-use PHPUnit\Framework\TestCase;
-use Psr\Container\ContainerExceptionInterface;
 use LmcRbac\Assertion\AssertionContainer;
 use LmcRbac\Assertion\AssertionInterface;
 use LmcRbacTest\Asset\SimpleAssertion;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * @covers \LmcRbac\Assertion\AssertionContainer

--- a/test/Assertion/AssertionContainerTest.php
+++ b/test/Assertion/AssertionContainerTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Assertion;
 
 use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\Factory\InvokableFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerExceptionInterface;
-use Laminas\ServiceManager\Factory\InvokableFactory;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Assertion\AssertionInterface;
 use ZfcRbacTest\Asset\SimpleAssertion;

--- a/test/Assertion/AssertionSetTest.php
+++ b/test/Assertion/AssertionSetTest.php
@@ -18,18 +18,18 @@ declare(strict_types=1);
  * and is licensed under the MIT license.
  */
 
-namespace ZfcRbacTest\Assertion;
+namespace LmcRbacTest\Assertion;
 
+use LmcRbac\Assertion\AssertionContainerInterface;
+use LmcRbac\Assertion\AssertionInterface;
+use LmcRbac\Assertion\AssertionSet;
+use LmcRbac\Exception\InvalidArgumentException;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbacTest\Asset\SimpleAssertion;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Assertion\AssertionContainerInterface;
-use ZfcRbac\Assertion\AssertionInterface;
-use ZfcRbac\Assertion\AssertionSet;
-use ZfcRbac\Exception\InvalidArgumentException;
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbacTest\Asset\SimpleAssertion;
 
 /**
- * @covers \ZfcRbac\Assertion\AssertionSet
+ * @covers \LmcRbac\Assertion\AssertionSet
  */
 class AssertionSetTest extends TestCase
 {

--- a/test/Asset/FlatRole.php
+++ b/test/Asset/FlatRole.php
@@ -19,11 +19,11 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 /**
  * @ORM\Entity

--- a/test/Asset/HierarchicalRole.php
+++ b/test/Asset/HierarchicalRole.php
@@ -19,12 +19,12 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use ZfcRbac\Role\HierarchicalRoleInterface;
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\HierarchicalRoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 /**
  * @ORM\Entity

--- a/test/Asset/Identity.php
+++ b/test/Asset/Identity.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Identity\IdentityInterface;
 
 class Identity implements IdentityInterface
 {

--- a/test/Asset/MockRoleWithPermissionMethod.php
+++ b/test/Asset/MockRoleWithPermissionMethod.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 class MockRoleWithPermissionMethod implements RoleInterface
 {

--- a/test/Asset/MockRoleWithPermissionProperty.php
+++ b/test/Asset/MockRoleWithPermissionProperty.php
@@ -19,9 +19,9 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleInterface;
 
 class MockRoleWithPermissionProperty implements RoleInterface
 {

--- a/test/Asset/SimpleAssertion.php
+++ b/test/Asset/SimpleAssertion.php
@@ -19,10 +19,10 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Asset;
+namespace LmcRbacTest\Asset;
 
-use ZfcRbac\Assertion\AssertionInterface;
-use ZfcRbac\Identity\IdentityInterface;
+use LmcRbac\Assertion\AssertionInterface;
+use LmcRbac\Identity\IdentityInterface;
 
 class SimpleAssertion implements AssertionInterface
 {

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -40,7 +40,7 @@ class ConfigProviderTest extends TestCase
                 \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => \ZfcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
                 \ZfcRbac\Service\AuthorizationServiceInterface::class => \ZfcRbac\Container\AuthorizationServiceFactory::class,
                 \ZfcRbac\Service\RoleServiceInterface::class => \ZfcRbac\Container\RoleServiceFactory::class,
-                \ZfcRbac\Rbac::class => \Zend\ServiceManager\Factory\InvokableFactory::class,
+                \ZfcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
             ],
         ];
         $this->assertEquals($expected, $provider->getDependencyConfig());

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -60,7 +60,7 @@ class ConfigProviderTest extends TestCase
         $provider = new ConfigProvider();
         $expected = [
             'dependencies' => $provider->getDependencyConfig(),
-            'zfc_rbac' => $provider->getModuleConfig(),
+            'lmc_rbac' => $provider->getModuleConfig(),
         ];
         $this->assertEquals($expected, $provider());
     }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -38,9 +38,9 @@ class ConfigProviderTest extends TestCase
                 \LmcRbac\Options\ModuleOptions::class => \LmcRbac\Container\ModuleOptionsFactory::class,
                 \LmcRbac\Role\InMemoryRoleProvider::class => \LmcRbac\Container\InMemoryRoleProviderFactory::class,
                 \LmcRbac\Role\ObjectRepositoryRoleProvider::class => \LmcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
-                \ZfcRbac\Service\AuthorizationServiceInterface::class => \ZfcRbac\Container\AuthorizationServiceFactory::class,
-                \ZfcRbac\Service\RoleServiceInterface::class => \ZfcRbac\Container\RoleServiceFactory::class,
-                \ZfcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
+                \LmcRbac\Service\AuthorizationServiceInterface::class => \LmcRbac\Container\AuthorizationServiceFactory::class,
+                \LmcRbac\Service\RoleServiceInterface::class => \LmcRbac\Container\RoleServiceFactory::class,
+                \LmcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,
             ],
         ];
         $this->assertEquals($expected, $provider->getDependencyConfig());

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace LmcRbacTest;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\ConfigProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers  \LmcRbac\ConfigProvider

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -19,13 +19,13 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest;
+namespace LmcRbacTest;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\ConfigProvider;
+use LmcRbac\ConfigProvider;
 
 /**
- * @covers  \ZfcRbac\ConfigProvider
+ * @covers  \LmcRbac\ConfigProvider
  */
 class ConfigProviderTest extends TestCase
 {
@@ -34,10 +34,10 @@ class ConfigProviderTest extends TestCase
         $provider = new ConfigProvider();
         $expected = [
             'factories' => [
-                \ZfcRbac\Assertion\AssertionContainerInterface::class => \ZfcRbac\Container\AssertionContainerFactory::class,
-                \ZfcRbac\Options\ModuleOptions::class => \ZfcRbac\Container\ModuleOptionsFactory::class,
-                \ZfcRbac\Role\InMemoryRoleProvider::class => \ZfcRbac\Container\InMemoryRoleProviderFactory::class,
-                \ZfcRbac\Role\ObjectRepositoryRoleProvider::class => \ZfcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
+                \LmcRbac\Assertion\AssertionContainerInterface::class => \LmcRbac\Container\AssertionContainerFactory::class,
+                \LmcRbac\Options\ModuleOptions::class => \LmcRbac\Container\ModuleOptionsFactory::class,
+                \LmcRbac\Role\InMemoryRoleProvider::class => \LmcRbac\Container\InMemoryRoleProviderFactory::class,
+                \LmcRbac\Role\ObjectRepositoryRoleProvider::class => \LmcRbac\Container\ObjectRepositoryRoleProviderFactory::class,
                 \ZfcRbac\Service\AuthorizationServiceInterface::class => \ZfcRbac\Container\AuthorizationServiceFactory::class,
                 \ZfcRbac\Service\RoleServiceInterface::class => \ZfcRbac\Container\RoleServiceFactory::class,
                 \ZfcRbac\Rbac::class => \Laminas\ServiceManager\Factory\InvokableFactory::class,

--- a/test/Container/AssertionContainerFactoryTest.php
+++ b/test/Container/AssertionContainerFactoryTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Container;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Container\AssertionContainerFactory;
 

--- a/test/Container/AssertionContainerFactoryTest.php
+++ b/test/Container/AssertionContainerFactoryTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace ZfcRbacTest\Container;
 
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Container\AssertionContainerFactory;
 

--- a/test/Container/AssertionContainerFactoryTest.php
+++ b/test/Container/AssertionContainerFactoryTest.php
@@ -35,7 +35,7 @@ class AssertionContainerFactoryTest extends TestCase
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService('config', [
-            'zfc_rbac' => [
+            'lmc_rbac' => [
                 'assertion_manager' => [],
             ],
         ]);

--- a/test/Container/AssertionContainerFactoryTest.php
+++ b/test/Container/AssertionContainerFactoryTest.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;

--- a/test/Container/AssertionContainerFactoryTest.php
+++ b/test/Container/AssertionContainerFactoryTest.php
@@ -22,12 +22,12 @@ declare(strict_types=1);
 namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
+use LmcRbac\Assertion\AssertionContainer;
+use LmcRbac\Container\AssertionContainerFactory;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Assertion\AssertionContainer;
-use ZfcRbac\Container\AssertionContainerFactory;
 
 /**
- * @covers \ZfcRbac\Container\AssertionContainerFactory
+ * @covers \LmcRbac\Container\AssertionContainerFactory
  */
 class AssertionContainerFactoryTest extends TestCase
 {

--- a/test/Container/AuthorizationServiceFactoryTest.php
+++ b/test/Container/AuthorizationServiceFactoryTest.php
@@ -19,19 +19,19 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
+use LmcRbac\Assertion\AssertionContainerInterface;
+use LmcRbac\Container\AuthorizationServiceFactory;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Rbac;
+use LmcRbac\Service\AuthorizationService;
+use LmcRbac\Service\RoleServiceInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use ZfcRbac\Assertion\AssertionContainerInterface;
-use ZfcRbac\Container\AuthorizationServiceFactory;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Rbac;
-use ZfcRbac\Service\AuthorizationService;
-use ZfcRbac\Service\RoleServiceInterface;
 
 /**
- * @covers \ZfcRbac\Container\AuthorizationServiceFactory
+ * @covers \LmcRbac\Container\AuthorizationServiceFactory
  */
 class AuthorizationServiceFactoryTest extends TestCase
 {

--- a/test/Container/InMemoryRoleProviderFactoryTest.php
+++ b/test/Container/InMemoryRoleProviderFactoryTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Container;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Container\InMemoryRoleProviderFactory;
 use ZfcRbac\Options\ModuleOptions;
 use ZfcRbac\Role\InMemoryRoleProvider;

--- a/test/Container/InMemoryRoleProviderFactoryTest.php
+++ b/test/Container/InMemoryRoleProviderFactoryTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace ZfcRbacTest\Container;
 
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Container\InMemoryRoleProviderFactory;
 use ZfcRbac\Options\ModuleOptions;
 use ZfcRbac\Role\InMemoryRoleProvider;

--- a/test/Container/InMemoryRoleProviderFactoryTest.php
+++ b/test/Container/InMemoryRoleProviderFactoryTest.php
@@ -19,16 +19,16 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
+use LmcRbac\Container\InMemoryRoleProviderFactory;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\InMemoryRoleProvider;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Container\InMemoryRoleProviderFactory;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\InMemoryRoleProvider;
 
 /**
- * @covers \ZfcRbac\Container\InMemoryRoleProviderFactory
+ * @covers \LmcRbac\Container\InMemoryRoleProviderFactory
  */
 class InMemoryRoleProviderFactoryTest extends TestCase
 {

--- a/test/Container/ModuleOptionsFactoryTest.php
+++ b/test/Container/ModuleOptionsFactoryTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Container;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Container\ModuleOptionsFactory;
 use ZfcRbac\Options\ModuleOptions;
 

--- a/test/Container/ModuleOptionsFactoryTest.php
+++ b/test/Container/ModuleOptionsFactoryTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Container\ModuleOptionsFactory;
 use LmcRbac\Options\ModuleOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Container\ModuleOptionsFactory

--- a/test/Container/ModuleOptionsFactoryTest.php
+++ b/test/Container/ModuleOptionsFactoryTest.php
@@ -19,15 +19,15 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Container\ModuleOptionsFactory;
-use ZfcRbac\Options\ModuleOptions;
+use LmcRbac\Container\ModuleOptionsFactory;
+use LmcRbac\Options\ModuleOptions;
 
 /**
- * @covers \ZfcRbac\Container\ModuleOptionsFactory
+ * @covers \LmcRbac\Container\ModuleOptionsFactory
  */
 class ModuleOptionsFactoryTest extends TestCase
 {

--- a/test/Container/ModuleOptionsFactoryTest.php
+++ b/test/Container/ModuleOptionsFactoryTest.php
@@ -33,7 +33,7 @@ class ModuleOptionsFactoryTest extends TestCase
 {
     public function testFactory(): void
     {
-        $config = ['zfc_rbac' => []];
+        $config = ['lmc_rbac' => []];
 
         $serviceManager = new ServiceManager();
         $serviceManager->setService('config', $config);

--- a/test/Container/ModuleOptionsFactoryTest.php
+++ b/test/Container/ModuleOptionsFactoryTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace ZfcRbacTest\Container;
 
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Container\ModuleOptionsFactory;
 use ZfcRbac\Options\ModuleOptions;
 

--- a/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
+++ b/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
@@ -24,7 +24,7 @@ namespace ZfcRbacTest\Container;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Container\ObjectRepositoryRoleProviderFactory;
 use ZfcRbac\Exception\RuntimeException;
 use ZfcRbac\Options\ModuleOptions;

--- a/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
+++ b/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
@@ -19,19 +19,19 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Container\ObjectRepositoryRoleProviderFactory;
-use ZfcRbac\Exception\RuntimeException;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\ObjectRepositoryRoleProvider;
+use LmcRbac\Container\ObjectRepositoryRoleProviderFactory;
+use LmcRbac\Exception\RuntimeException;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\ObjectRepositoryRoleProvider;
 
 /**
- * @covers \ZfcRbac\Container\ObjectRepositoryRoleProviderFactory
+ * @covers \LmcRbac\Container\ObjectRepositoryRoleProviderFactory
  */
 class ObjectRepositoryRoleProviderFactoryTest extends TestCase
 {
@@ -99,7 +99,7 @@ class ObjectRepositoryRoleProviderFactoryTest extends TestCase
     public function testThrowExceptionIfNoObjectManagerNorObjectRepositoryIsSet(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('No object repository was found while creating the ZfcRbac object repository role provider. Are
+        $this->expectExceptionMessage('No object repository was found while creating the LmcRbac object repository role provider. Are
              you sure you specified either the "object_repository" option or "object_manager"/"class_name" options?');
 
         $container = new ServiceManager();

--- a/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
+++ b/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
@@ -24,11 +24,11 @@ namespace LmcRbacTest\Container;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Laminas\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Container\ObjectRepositoryRoleProviderFactory;
 use LmcRbac\Exception\RuntimeException;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\ObjectRepositoryRoleProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Container\ObjectRepositoryRoleProviderFactory

--- a/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
+++ b/test/Container/ObjectRepositoryRoleProviderFactoryTest.php
@@ -23,8 +23,8 @@ namespace ZfcRbacTest\Container;
 
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Container\ObjectRepositoryRoleProviderFactory;
 use ZfcRbac\Exception\RuntimeException;
 use ZfcRbac\Options\ModuleOptions;

--- a/test/Container/RoleServiceFactoryTest.php
+++ b/test/Container/RoleServiceFactoryTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Container;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Container\RoleServiceFactory;
 use ZfcRbac\Options\ModuleOptions;
 use ZfcRbac\Role\InMemoryRoleProvider;

--- a/test/Container/RoleServiceFactoryTest.php
+++ b/test/Container/RoleServiceFactoryTest.php
@@ -19,17 +19,17 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Container;
+namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Container\RoleServiceFactory;
-use ZfcRbac\Options\ModuleOptions;
-use ZfcRbac\Role\InMemoryRoleProvider;
-use ZfcRbac\Role\RoleProviderInterface;
+use LmcRbac\Container\RoleServiceFactory;
+use LmcRbac\Options\ModuleOptions;
+use LmcRbac\Role\InMemoryRoleProvider;
+use LmcRbac\Role\RoleProviderInterface;
 
 /**
- * @covers \ZfcRbac\Container\RoleServiceFactory
+ * @covers \LmcRbac\Container\RoleServiceFactory
  */
 class RoleServiceFactoryTest extends TestCase
 {
@@ -38,7 +38,7 @@ class RoleServiceFactoryTest extends TestCase
         $options = new ModuleOptions([
             'guest_role' => 'guest',
             'role_provider' => [
-                \ZfcRbac\Role\InMemoryRoleProvider::class => [
+                \LmcRbac\Role\InMemoryRoleProvider::class => [
                     'foo',
                 ],
             ],
@@ -52,7 +52,7 @@ class RoleServiceFactoryTest extends TestCase
         $factory = new RoleServiceFactory();
         $roleService = $factory($container);
 
-        $this->assertInstanceOf(\ZfcRbac\Service\RoleService::class, $roleService);
+        $this->assertInstanceOf(\LmcRbac\Service\RoleService::class, $roleService);
     }
 
     public function testThrowExceptionIfNoRoleProvider(): void

--- a/test/Container/RoleServiceFactoryTest.php
+++ b/test/Container/RoleServiceFactoryTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace ZfcRbacTest\Container;
 
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Container\RoleServiceFactory;
 use ZfcRbac\Options\ModuleOptions;
 use ZfcRbac\Role\InMemoryRoleProvider;

--- a/test/Container/RoleServiceFactoryTest.php
+++ b/test/Container/RoleServiceFactoryTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 namespace LmcRbacTest\Container;
 
 use Laminas\ServiceManager\ServiceManager;
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Container\RoleServiceFactory;
 use LmcRbac\Options\ModuleOptions;
 use LmcRbac\Role\InMemoryRoleProvider;
 use LmcRbac\Role\RoleProviderInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Container\RoleServiceFactory

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -19,14 +19,14 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest;
+namespace LmcRbacTest;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\ConfigProvider;
-use ZfcRbac\Module;
+use LmcRbac\ConfigProvider;
+use LmcRbac\Module;
 
 /**
- * @covers  \ZfcRbac\Module
+ * @covers  \LmcRbac\Module
  */
 class ModuleTest extends TestCase
 {

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -36,7 +36,7 @@ class ModuleTest extends TestCase
         $module = new Module();
         $expected = [
             'service_manager' => $provider->getDependencyConfig(),
-            'zfc_rbac' => $provider->getModuleConfig(),
+            'lmc_rbac' => $provider->getModuleConfig(),
         ];
         $this->assertEquals($expected, $module->getConfig());
     }

--- a/test/ModuleTest.php
+++ b/test/ModuleTest.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 
 namespace LmcRbacTest;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\ConfigProvider;
 use LmcRbac\Module;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers  \LmcRbac\Module

--- a/test/Options/ModuleOptionsTest.php
+++ b/test/Options/ModuleOptionsTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace LmcRbacTest\Options;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Options\ModuleOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Options\ModuleOptions

--- a/test/Options/ModuleOptionsTest.php
+++ b/test/Options/ModuleOptionsTest.php
@@ -19,20 +19,20 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Options;
+namespace LmcRbacTest\Options;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Options\ModuleOptions;
+use LmcRbac\Options\ModuleOptions;
 
 /**
- * @covers \ZfcRbac\Options\ModuleOptions
+ * @covers \LmcRbac\Options\ModuleOptions
  */
 class ModuleOptionsTest extends TestCase
 {
     public function testAssertModuleDefaultOptions(): void
     {
-        /** @var \ZfcRbac\Options\ModuleOptions $moduleOptions */
-        $moduleOptions = new \ZfcRbac\Options\ModuleOptions();
+        /** @var \LmcRbac\Options\ModuleOptions $moduleOptions */
+        $moduleOptions = new \LmcRbac\Options\ModuleOptions();
 
         $this->assertEquals('guest', $moduleOptions->getGuestRole());
         $this->assertIsArray($moduleOptions->getRoleProvider());

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -19,21 +19,21 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest;
+namespace LmcRbacTest;
 
+use LmcRbac\Rbac;
+use LmcRbac\Role\HierarchicalRole;
+use LmcRbac\Role\Role;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Rbac;
-use ZfcRbac\Role\HierarchicalRole;
-use ZfcRbac\Role\Role;
 
 /**
- * @covers \ZfcRbac\Rbac
+ * @covers \LmcRbac\Rbac
  * @group  Coverage
  */
 class RbacTest extends TestCase
 {
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testCanConvertSingleRole(): void
     {
@@ -46,7 +46,7 @@ class RbacTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testCanUseEmptyArray(): void
     {
@@ -55,7 +55,7 @@ class RbacTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testCanCheckMultipleRolesWithMatchingPermission(): void
     {
@@ -71,7 +71,7 @@ class RbacTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testReturnFalseIfNoRoleHasPermission(): void
     {
@@ -79,13 +79,13 @@ class RbacTest extends TestCase
         $role2 = new Role('Bar');
 
         $roles = [$role1, $role2];
-        $rbac = new \ZfcRbac\Rbac();
+        $rbac = new \LmcRbac\Rbac();
 
         $this->assertFalse($rbac->isGranted($roles, 'permission'));
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testCanCheckHierarchicalRole(): void
     {
@@ -95,13 +95,13 @@ class RbacTest extends TestCase
         $parentRole = new HierarchicalRole('Foo');
         $parentRole->addChild($childRole);
 
-        $rbac = new \ZfcRbac\Rbac();
+        $rbac = new \LmcRbac\Rbac();
 
         $this->assertTrue($rbac->isGranted($parentRole, 'permission'));
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testReturnFalseIfNoHierarchicalRoleHasPermission(): void
     {
@@ -116,7 +116,7 @@ class RbacTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Rbac::isGranted
+     * @covers \LmcRbac\Rbac::isGranted
      */
     public function testCanCheckTraversableAsRolesList(): void
     {

--- a/test/Role/HierarchicalRoleTest.php
+++ b/test/Role/HierarchicalRoleTest.php
@@ -19,20 +19,20 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Role;
+namespace LmcRbacTest\Role;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Role\HierarchicalRole;
-use ZfcRbac\Role\HierarchicalRoleInterface;
+use LmcRbac\Role\HierarchicalRole;
+use LmcRbac\Role\HierarchicalRoleInterface;
 
 /**
- * @covers \ZfcRbac\Role\HierarchicalRole
+ * @covers \LmcRbac\Role\HierarchicalRole
  * @group  Coverage
  */
 class HierarchicalRoleTest extends TestCase
 {
     /**
-     * @covers \ZfcRbac\Role\HierarchicalRole::addChild
+     * @covers \LmcRbac\Role\HierarchicalRole::addChild
      */
     public function testCanAddChild(): void
     {
@@ -45,7 +45,7 @@ class HierarchicalRoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\HierarchicalRole::hasChildren
+     * @covers \LmcRbac\Role\HierarchicalRole::hasChildren
      */
     public function testHasChildren(): void
     {
@@ -59,7 +59,7 @@ class HierarchicalRoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\HierarchicalRole::getChildren
+     * @covers \LmcRbac\Role\HierarchicalRole::getChildren
      */
     public function testCanGetChildren(): void
     {
@@ -77,7 +77,7 @@ class HierarchicalRoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\HierarchicalRole::addPermission
+     * @covers \LmcRbac\Role\HierarchicalRole::addPermission
      */
     public function testRoleCanAddPermission(): void
     {
@@ -89,7 +89,7 @@ class HierarchicalRoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\HierarchicalRole::getPermissions
+     * @covers \LmcRbac\Role\HierarchicalRole::getPermissions
      */
     public function testRoleCanGetPermissions(): void
     {

--- a/test/Role/HierarchicalRoleTest.php
+++ b/test/Role/HierarchicalRoleTest.php
@@ -21,9 +21,9 @@ declare(strict_types=1);
 
 namespace LmcRbacTest\Role;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Role\HierarchicalRole;
 use LmcRbac\Role\HierarchicalRoleInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Role\HierarchicalRole

--- a/test/Role/InMemoryRoleProviderTest.php
+++ b/test/Role/InMemoryRoleProviderTest.php
@@ -21,10 +21,10 @@ declare(strict_types=1);
 
 namespace LmcRbacTest\Role;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Role\HierarchicalRoleInterface;
 use LmcRbac\Role\InMemoryRoleProvider;
 use LmcRbac\Role\RoleInterface;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Role\InMemoryRoleProvider

--- a/test/Role/InMemoryRoleProviderTest.php
+++ b/test/Role/InMemoryRoleProviderTest.php
@@ -19,15 +19,15 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Role;
+namespace LmcRbacTest\Role;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Role\HierarchicalRoleInterface;
-use ZfcRbac\Role\InMemoryRoleProvider;
-use ZfcRbac\Role\RoleInterface;
+use LmcRbac\Role\HierarchicalRoleInterface;
+use LmcRbac\Role\InMemoryRoleProvider;
+use LmcRbac\Role\RoleInterface;
 
 /**
- * @covers \ZfcRbac\Role\InMemoryRoleProvider
+ * @covers \LmcRbac\Role\InMemoryRoleProvider
  */
 class InMemoryRoleProviderTest extends TestCase
 {

--- a/test/Role/ObjectRepositoryRoleProviderTest.php
+++ b/test/Role/ObjectRepositoryRoleProviderTest.php
@@ -22,9 +22,9 @@ declare(strict_types=1);
 namespace LmcRbacTest\Role;
 
 use Doctrine\Common\Persistence\ObjectRepository;
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Role\ObjectRepositoryRoleProvider;
 use LmcRbacTest\Asset\FlatRole;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Role\ObjectRepositoryRoleProvider

--- a/test/Role/ObjectRepositoryRoleProviderTest.php
+++ b/test/Role/ObjectRepositoryRoleProviderTest.php
@@ -19,15 +19,15 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Role;
+namespace LmcRbacTest\Role;
 
 use Doctrine\Common\Persistence\ObjectRepository;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Role\ObjectRepositoryRoleProvider;
-use ZfcRbacTest\Asset\FlatRole;
+use LmcRbac\Role\ObjectRepositoryRoleProvider;
+use LmcRbacTest\Asset\FlatRole;
 
 /**
- * @covers \ZfcRbac\Role\ObjectRepositoryRoleProvider
+ * @covers \LmcRbac\Role\ObjectRepositoryRoleProvider
  */
 class ObjectRepositoryRoleProviderTest extends TestCase
 {
@@ -81,7 +81,7 @@ class ObjectRepositoryRoleProviderTest extends TestCase
 
         $objectRepository->expects($this->once())->method('findBy')->will($this->returnValue($result));
 
-        $this->expectException('ZfcRbac\Exception\RoleNotFoundException');
+        $this->expectException('LmcRbac\Exception\RoleNotFoundException');
         $this->expectExceptionMessage('Some roles were asked but could not be loaded from database: guest, admin');
 
         $provider->getRoles(['guest', 'admin', 'member']);

--- a/test/Role/RoleTest.php
+++ b/test/Role/RoleTest.php
@@ -19,13 +19,13 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Role;
+namespace LmcRbacTest\Role;
 
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Role\Role;
+use LmcRbac\Role\Role;
 
 /**
- * @covers \ZfcRbac\Role\Role
+ * @covers \LmcRbac\Role\Role
  * @group Coverage
  */
 class RoleTest extends TestCase
@@ -37,7 +37,7 @@ class RoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\Role::addPermission
+     * @covers \LmcRbac\Role\Role::addPermission
      */
     public function testRoleCanAddPermission(): void
     {
@@ -52,7 +52,7 @@ class RoleTest extends TestCase
     }
 
     /**
-     * @covers \ZfcRbac\Role\Role::getPermissions
+     * @covers \LmcRbac\Role\Role::getPermissions
      */
     public function testRoleCanGetPermissions(): void
     {

--- a/test/Role/RoleTest.php
+++ b/test/Role/RoleTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace LmcRbacTest\Role;
 
-use PHPUnit\Framework\TestCase;
 use LmcRbac\Role\Role;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \LmcRbac\Role\Role

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 namespace ZfcRbacTest\Service;
 
 use PHPUnit\Framework\TestCase;
-use Zend\ServiceManager\ServiceManager;
+use Laminas\ServiceManager\ServiceManager;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Assertion\AssertionContainerInterface;
 use ZfcRbac\Assertion\AssertionSet;

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Service;
+namespace LmcRbacTest\Service;
 
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -22,24 +22,24 @@ declare(strict_types=1);
 namespace LmcRbacTest\Service;
 
 use Laminas\ServiceManager\ServiceManager;
+use LmcRbac\Assertion\AssertionContainer;
+use LmcRbac\Assertion\AssertionContainerInterface;
+use LmcRbac\Assertion\AssertionSet;
+use LmcRbac\Exception\InvalidArgumentException;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbac\Rbac;
+use LmcRbac\Role\InMemoryRoleProvider;
+use LmcRbac\Role\RoleInterface;
+use LmcRbac\Service\AuthorizationService;
+use LmcRbac\Service\RoleService;
+use LmcRbac\Service\RoleServiceInterface;
+use LmcRbacTest\Asset\FlatRole;
+use LmcRbacTest\Asset\Identity;
+use LmcRbacTest\Asset\SimpleAssertion;
 use PHPUnit\Framework\TestCase;
-use ZfcRbac\Assertion\AssertionContainer;
-use ZfcRbac\Assertion\AssertionContainerInterface;
-use ZfcRbac\Assertion\AssertionSet;
-use ZfcRbac\Exception\InvalidArgumentException;
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Rbac;
-use ZfcRbac\Role\InMemoryRoleProvider;
-use ZfcRbac\Role\RoleInterface;
-use ZfcRbac\Service\AuthorizationService;
-use ZfcRbac\Service\RoleService;
-use ZfcRbac\Service\RoleServiceInterface;
-use ZfcRbacTest\Asset\FlatRole;
-use ZfcRbacTest\Asset\Identity;
-use ZfcRbacTest\Asset\SimpleAssertion;
 
 /**
- * @covers \ZfcRbac\Service\AuthorizationService
+ * @covers \LmcRbac\Service\AuthorizationService
  */
 class AuthorizationServiceTest extends TestCase
 {

--- a/test/Service/AuthorizationServiceTest.php
+++ b/test/Service/AuthorizationServiceTest.php
@@ -21,8 +21,8 @@ declare(strict_types=1);
 
 namespace ZfcRbacTest\Service;
 
-use PHPUnit\Framework\TestCase;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 use ZfcRbac\Assertion\AssertionContainer;
 use ZfcRbac\Assertion\AssertionContainerInterface;
 use ZfcRbac\Assertion\AssertionSet;

--- a/test/Service/RoleServiceTest.php
+++ b/test/Service/RoleServiceTest.php
@@ -19,21 +19,21 @@
 
 declare(strict_types=1);
 
-namespace ZfcRbacTest\Service;
+namespace LmcRbacTest\Service;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use ZfcRbac\Identity\IdentityInterface;
-use ZfcRbac\Role\HierarchicalRole;
-use ZfcRbac\Role\InMemoryRoleProvider;
-use ZfcRbac\Role\Role;
-use ZfcRbac\Role\RoleInterface;
-use ZfcRbac\Role\RoleProviderInterface;
-use ZfcRbac\Service\RoleService;
-use ZfcRbacTest\Asset\Identity;
+use LmcRbac\Identity\IdentityInterface;
+use LmcRbac\Role\HierarchicalRole;
+use LmcRbac\Role\InMemoryRoleProvider;
+use LmcRbac\Role\Role;
+use LmcRbac\Role\RoleInterface;
+use LmcRbac\Role\RoleProviderInterface;
+use LmcRbac\Service\RoleService;
+use LmcRbacTest\Asset\Identity;
 
 /**
- * @covers \ZfcRbac\Service\RoleService
+ * @covers \LmcRbac\Service\RoleService
  */
 class RoleServiceTest extends TestCase
 {

--- a/test/Service/RoleServiceTest.php
+++ b/test/Service/RoleServiceTest.php
@@ -21,8 +21,6 @@ declare(strict_types=1);
 
 namespace LmcRbacTest\Service;
 
-use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use LmcRbac\Identity\IdentityInterface;
 use LmcRbac\Role\HierarchicalRole;
 use LmcRbac\Role\InMemoryRoleProvider;
@@ -31,6 +29,8 @@ use LmcRbac\Role\RoleInterface;
 use LmcRbac\Role\RoleProviderInterface;
 use LmcRbac\Service\RoleService;
 use LmcRbacTest\Asset\Identity;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 
 /**
  * @covers \LmcRbac\Service\RoleService


### PR DESCRIPTION
- builds on PR from https://github.com/ZF-Commons/zfc-rbac/pull/393
- changed org namespace
- changed packagist name
- documentation still outdated
- not sure what to put here: https://github.com/basz/LmcRbac/blob/laminas-commons-migration/composer.json#L61-L64

next steps
- remove all releases from this repo
- not sure if this would be a valid idea; https://getcomposer.org/doc/04-schema.md#replace
- add deprecation message in ZFCommons and archive it...

cc @svycka