### PR TITLE
Better return type

### DIFF
--- a/src/Role/HierarchicalRoleInterface.php
+++ b/src/Role/HierarchicalRoleInterface.php
@@ -31,7 +31,7 @@ interface HierarchicalRoleInterface extends RoleInterface
     public function hasChildren(): bool;
 
     /**
-     * @return RoleInterface[]
+     * @return iterable<RoleInterface>
      */
     public function getChildren(): iterable;
 }


### PR DESCRIPTION
this will help prevent this:
```
ERROR: InvalidReturnStatement - Entity/HierarchicalRole.php:122:16 - The inferred type 'Doctrine\Common\Collections\Collection|array<array-key, LmcRbac\Role\HierarchicalRoleInterface>' does not match the declared return type 'iterable<int, LmcRbac\Role\RoleInterface>' for Entity\HierarchicalRole::getChildren (see https://psalm.dev/128)
        return $this->children;
```